### PR TITLE
Pass translation key for login and auth prompts

### DIFF
--- a/jscomps/PromptService.js
+++ b/jscomps/PromptService.js
@@ -119,8 +119,8 @@ InternalPrompt.prototype = {
       title: aTitle,
       message: aText,
       buttons: aButtons || [
-        PromptUtils.getLocaleString("OK"),
-        PromptUtils.getLocaleString("Cancel")
+        "OK",
+        "Cancel"
       ]
     });
     return p;
@@ -239,13 +239,13 @@ InternalPrompt.prototype = {
   /* ----------  nsIPrompt  ---------- */
 
   alert: function alert(aTitle, aText) {
-    let p = this._getPrompt(aTitle, aText, [ PromptUtils.getLocaleString("OK") ]);
+    let p = this._getPrompt(aTitle, aText, [ "OK" ]);
     p.setHint("alert");
     this.showPrompt(p);
   },
 
   alertCheck: function alertCheck(aTitle, aText, aCheckMsg, aCheckState) {
-    let p = this._getPrompt(aTitle, aText, [ PromptUtils.getLocaleString("OK") ]);
+    let p = this._getPrompt(aTitle, aText, [ "OK" ]);
     p.setHint("alert");
     this.addCheckbox(p, aCheckMsg, aCheckState, "preventAddionalDialog");
     let data = this.showPrompt(p);
@@ -279,25 +279,25 @@ InternalPrompt.prototype = {
       let bTitle = null;
       switch (aButtonFlags & 0xff) {
         case Ci.nsIPromptService.BUTTON_TITLE_OK :
-          bTitle = PromptUtils.getLocaleString("OK");
+          bTitle = "OK";
           break;
         case Ci.nsIPromptService.BUTTON_TITLE_CANCEL :
-          bTitle = PromptUtils.getLocaleString("Cancel");
+          bTitle = "Cancel";
           break;
         case Ci.nsIPromptService.BUTTON_TITLE_YES :
-          bTitle = PromptUtils.getLocaleString("Yes");
+          bTitle = "Yes";
           break;
         case Ci.nsIPromptService.BUTTON_TITLE_NO :
-          bTitle = PromptUtils.getLocaleString("No");
+          bTitle = "No";
           break;
         case Ci.nsIPromptService.BUTTON_TITLE_SAVE :
-          bTitle = PromptUtils.getLocaleString("Save");
+          bTitle = "Save";
           break;
         case Ci.nsIPromptService.BUTTON_TITLE_DONT_SAVE :
-          bTitle = PromptUtils.getLocaleString("DontSave");
+          bTitle = "DontSave";
           break;
         case Ci.nsIPromptService.BUTTON_TITLE_REVERT :
-          bTitle = PromptUtils.getLocaleString("Revert");
+          bTitle = "Revert";
           break;
         case Ci.nsIPromptService.BUTTON_TITLE_IS_STRING :
           bTitle = PromptUtils.cleanUpLabel(titles[i]);
@@ -339,7 +339,7 @@ InternalPrompt.prototype = {
     let p = this._getPrompt(aTitle, aText, null);
     p.setHint("auth");
     p.setPrivateBrowsing(this._privateBrowsing);
-    this.addPassword(p, aPassword.value, true, PromptUtils.getLocaleString("password", "passwdmgr"));
+    this.addPassword(p, aPassword.value, true, "password");
     this.addCheckbox(p, aCheckMsg, aCheckState, "remember");
     let data = this.showPrompt(p);
 
@@ -358,8 +358,8 @@ InternalPrompt.prototype = {
     let p = this._getPrompt(aTitle, aText, null);
     p.setHint("auth");
     p.setPrivateBrowsing(this._privateBrowsing);
-    this.addTextbox(p, aUsername.value, true, PromptUtils.getLocaleString("username", "passwdmgr"));
-    this.addPassword(p, aPassword.value, false, PromptUtils.getLocaleString("password", "passwdmgr"));
+    this.addTextbox(p, aUsername.value, true, "username");
+    this.addPassword(p, aPassword.value, false, "password");
     this.addCheckbox(p, aCheckMsg, aCheckState, "remember");
     let data = this.showPrompt(p);
 
@@ -377,11 +377,13 @@ InternalPrompt.prototype = {
 
   nonlocalized_promptPassword: function nonlocalized_promptPassword(
       aTitle, aMessage, aHostname, aHttpRealm, aPassword, aCheckMsg, aCheckState) {
-    let p = this._getPrompt(aTitle, aMessage, null);
+    // We abuse the Gecko-to-Qt translation key conversion process by providing a key for the
+    // accept button that isn't actually available in gecko, but which we need in the front end
+    let p = this._getPrompt(aTitle, aMessage, [ "AcceptLogin" ]);
     p.setHint("auth");
     p.setPrivateBrowsing(this._privateBrowsing);
     p.addHostInfo(aHostname, aHttpRealm);
-    this.addPassword(p, aPassword.value, true, PromptUtils.getLocaleString("password", "passwdmgr"));
+    this.addPassword(p, aPassword.value, true, "password");
     this.addCheckbox(p, aCheckMsg, aCheckState, "remember");
     let data = this.showPrompt(p);
 
@@ -397,12 +399,14 @@ InternalPrompt.prototype = {
 
   nonlocalized_promptUsernameAndPassword: function nonlocalized_promptUsernameAndPassword(
       aTitle, aMessage, aHostname, aHttpRealm, aUsername, aPassword, aCheckMsg, aCheckState) {
-    let p = this._getPrompt(aTitle, aMessage, null);
+    // We abuse the Gecko-to-Qt translation key conversion process by providing a key for the
+    // accept button that isn't actually available in gecko, but which we need in the front end
+    let p = this._getPrompt(aTitle, aMessage, [ "AcceptLogin" ]);
     p.setHint("auth");
     p.setPrivateBrowsing(this._privateBrowsing);
     this.addHostInfo(p, aHostname, aHttpRealm);
-    this.addTextbox(p, aUsername.value, true, PromptUtils.getLocaleString("username", "passwdmgr"));
-    this.addPassword(p, aPassword.value, false, PromptUtils.getLocaleString("password", "passwdmgr"));
+    this.addTextbox(p, aUsername.value, true, "username");
+    this.addPassword(p, aPassword.value, false, "password");
     this.addCheckbox(p, aCheckMsg, aCheckState, "remember");
     let data = this.showPrompt(p);
 
@@ -419,7 +423,7 @@ InternalPrompt.prototype = {
   },
 
   select: function select(aTitle, aText, aCount, aSelectList, aOutSelection) {
-    let p = this._getPrompt(aTitle, aText, [ PromptUtils.getLocaleString("OK") ]);
+    let p = this._getPrompt(aTitle, aText, [ "OK" ]);
     p.setHint("select");
     p.addMenulist({ values: aSelectList });
     let data = this.showPrompt(p);
@@ -621,11 +625,6 @@ InternalPrompt.prototype = {
 };
 
 var PromptUtils = {
-  getLocaleString: function pu_getLocaleString(aKey, aService) {
-    // This will not localize anything.
-    return aKey;
-  },
-
   //
   // Copied from chrome://global/content/commonDialog.js
   //

--- a/jsscripts/Prompt.jsm
+++ b/jsscripts/Prompt.jsm
@@ -71,6 +71,10 @@ Prompt.prototype = {
     return this;
   },
 
+  addHiddenValue: function(aKey, aValue) {
+    this.msg[aKey] = aValue;
+  },
+
   setPrivateBrowsing: function(aPrivateBrowsing) {
     if (!aPrivateBrowsing)
       delete this.msg.privateBrowsing;


### PR DESCRIPTION
Passes the gecko translation keys along with the form data to the browser UI components for auth and login dialogs. This allows localization to be performed in the UI.