### PR TITLE
Ensure EmbedLiteConsoleListener starts up first. JB#54970 OMP#JOLLA-270

### DIFF
--- a/jscomps/EmbedLiteConsoleListener.js
+++ b/jscomps/EmbedLiteConsoleListener.js
@@ -158,11 +158,13 @@ function LogChannelInfo(aSubject) {
   }
 }
 
-function EmbedLiteConsoleListener()
+// Prefix the component name with $ to ensure it is initalised
+// before all other components in the start-up sequence.
+function $EmbedLiteConsoleListener()
 {
 }
 
-EmbedLiteConsoleListener.prototype = {
+$EmbedLiteConsoleListener.prototype = {
   classID: Components.ID("{6b21b5a8-9816-11e2-86f8-fb54170a814d}"),
   _listener: null,
 
@@ -234,4 +236,4 @@ EmbedLiteConsoleListener.prototype = {
   QueryInterface: XPCOMUtils.generateQI([Ci.nsIObserver, Ci.nsISupportsWeakReference])
 };
 
-this.NSGetFactory = XPCOMUtils.generateNSGetFactory([EmbedLiteConsoleListener]);
+this.NSGetFactory = XPCOMUtils.generateNSGetFactory([$EmbedLiteConsoleListener]);

--- a/jscomps/EmbedLiteJSComponents.manifest
+++ b/jscomps/EmbedLiteJSComponents.manifest
@@ -1,7 +1,7 @@
 # EmbedLiteConsoleListener.js
 component {6b21b5a8-9816-11e2-86f8-fb54170a814d} EmbedLiteConsoleListener.js
 contract @mozilla.org/embedlite-console-listener;1 {6b21b5a8-9816-11e2-86f8-fb54170a814d}
-category app-startup EmbedLiteConsoleListener service,@mozilla.org/embedlite-console-listener;1
+category app-startup $EmbedLiteConsoleListener service,@mozilla.org/embedlite-console-listener;1
 
 # AlertsService.js
 component {b98ab6b8-6c88-11e2-99bc-6745f7369235} AlertsService.js


### PR DESCRIPTION
Any privileged components in embedlite-components that start up before
EmbedLiteConsoleListener aren't able to log. Since the start-up sequence
is alphabetical based on the component class name, this change ensures
the EmbedLiteConsoleListener is started before other components.