### PR TITLE
[embedlite-components] Move UserAgentOverrides.jsm to embedlite-components. Contributes to JB#55142

### DIFF
--- a/embedlite-components.pro
+++ b/embedlite-components.pro
@@ -19,4 +19,6 @@ OTHER_FILES += \
     overrides/fi/* \
     overrides/ru/* \
     tools/*.py \
-    configure.ac
+    configure.ac \
+    link_to_system.sh \
+    rpm/*.spec

--- a/jscomps/UserAgentOverrideHelper.js
+++ b/jscomps/UserAgentOverrideHelper.js
@@ -16,6 +16,7 @@ const PREF_OVERRIDE             = "general.useragent.override";
 
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+const { UserAgentOverrides } = ChromeUtils.import("chrome://embedlite/content/UserAgentOverrides.jsm");
 
 Services.scriptloader.loadSubScript("chrome://embedlite/content/Logger.js");
 
@@ -96,7 +97,6 @@ var UserAgent = {
                              "http-on-modify-request");
     Services.prefs.addObserver(PREF_OVERRIDE, this, false);
     this._customUA = this.getCustomUserAgent();
-    ChromeUtils.import("resource://gre/modules/UserAgentOverrides.jsm");
     UserAgentOverrides.init();
     UserAgentOverrides.addComplexOverride(this.onRequest.bind(this));
     // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox

--- a/jsscripts/Makefile.am
+++ b/jsscripts/Makefile.am
@@ -6,6 +6,8 @@ jsscripts_manifest_DATA = \
 	FormAssistant.js \
 	ContentLinkHandler.jsm \
 	OrientationChangeHandler.jsm \
+	UserAgentUpdates.jsm \
+	UserAgentOverrides.jsm \
 	SelectAsyncHelper.js \
 	SelectionHandler.js \
 	SelectionPrototype.js \

--- a/jsscripts/UserAgentOverrides.jsm
+++ b/jsscripts/UserAgentOverrides.jsm
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Ported from esr60 sha1 682b1ec3b2c92831a0ea97754ce4fdd00b9497ae
+// https://git.sailfishos.org/mirror/gecko-dev/blob/esr60/netwerk/protocol/http/UserAgentOverrides.jsm
+// With some esr78 compatibility changes applied.
+
+"use strict";
+
+var EXPORTED_SYMBOLS = [ "UserAgentOverrides" ];
+
+const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+ChromeUtils.import("chrome://embedlite/content/UserAgentUpdates.jsm");
+
+const PREF_OVERRIDES_ENABLED = "general.useragent.site_specific_overrides";
+const MAX_OVERRIDE_FOR_HOST_CACHE_SIZE = 250;
+
+// lazy load nsHttpHandler to improve startup performance.
+XPCOMUtils.defineLazyGetter(this, "DEFAULT_UA", function() {
+  return Cc["@mozilla.org/network/protocol;1?name=http"]
+           .getService(Ci.nsIHttpProtocolHandler)
+           .userAgent;
+});
+
+var gPrefBranch;
+var gOverrides = new Map;
+var gUpdatedOverrides;
+var gOverrideForHostCache = new Map;
+var gInitialized = false;
+var gOverrideFunctions = [
+  function (aHttpChannel) { return UserAgentOverrides.getOverrideForURI(aHttpChannel.URI); }
+];
+var gBuiltUAs = new Map;
+
+var UserAgentOverrides = {
+  init: function uao_init() {
+    if (gInitialized)
+      return;
+
+    gPrefBranch = Services.prefs.getBranch("general.useragent.override.");
+    gPrefBranch.addObserver("", buildOverrides);
+
+    Services.prefs.addObserver(PREF_OVERRIDES_ENABLED, buildOverrides);
+
+    try {
+      Services.obs.addObserver(HTTP_on_useragent_request, "http-on-useragent-request");
+    } catch (x) {
+      // The http-on-useragent-request notification is disallowed in content processes.
+    }
+
+    try {
+      UserAgentUpdates.init(function(overrides) {
+        gOverrideForHostCache.clear();
+        if (overrides) {
+          for (let domain in overrides) {
+            overrides[domain] = getUserAgentFromOverride(overrides[domain]);
+          }
+          overrides.get = function(key) { return this[key]; };
+        }
+        gUpdatedOverrides = overrides;
+      });
+
+      buildOverrides();
+    } catch (e) {
+      // UserAgentOverrides is initialized before profile is ready.
+      // UA override might not work correctly.
+    }
+
+    Services.obs.notifyObservers(null, "useragentoverrides-initialized");
+    gInitialized = true;
+  },
+
+  addComplexOverride: function uao_addComplexOverride(callback) {
+    // Add to front of array so complex overrides have precedence
+    gOverrideFunctions.unshift(callback);
+  },
+
+  getOverrideForURI: function uao_getOverrideForURI(aURI) {
+    let host = aURI.asciiHost;
+    if (!gInitialized ||
+        (!gOverrides.size && !gUpdatedOverrides) ||
+        !(host)) {
+      return null;
+    }
+
+    let override = gOverrideForHostCache.get(host);
+    if (override !== undefined)
+      return override;
+
+    function findOverride(overrides) {
+      let searchHost = host;
+      let userAgent = overrides.get(searchHost);
+
+      while (!userAgent) {
+        let dot = searchHost.indexOf('.');
+        if (dot === -1) {
+          return null;
+        }
+        searchHost = searchHost.slice(dot + 1);
+        userAgent = overrides.get(searchHost);
+      }
+      return userAgent;
+    }
+
+    override = (gOverrides.size && findOverride(gOverrides))
+            || (gUpdatedOverrides && findOverride(gUpdatedOverrides));
+
+    if (gOverrideForHostCache.size >= MAX_OVERRIDE_FOR_HOST_CACHE_SIZE) {
+      gOverrideForHostCache.clear();
+    }
+    gOverrideForHostCache.set(host, override);
+
+    return override;
+  },
+
+  uninit: function uao_uninit() {
+    if (!gInitialized)
+      return;
+    gInitialized = false;
+
+    gPrefBranch.removeObserver("", buildOverrides);
+
+    Services.prefs.removeObserver(PREF_OVERRIDES_ENABLED, buildOverrides);
+
+    Services.obs.removeObserver(HTTP_on_useragent_request, "http-on-useragent-request");
+  }
+};
+
+function getUserAgentFromOverride(override)
+{
+  let userAgent = gBuiltUAs.get(override);
+  if (userAgent !== undefined) {
+    return userAgent;
+  }
+  let [search, replace] = override.split("#", 2);
+  if (search && replace) {
+    userAgent = DEFAULT_UA.replace(new RegExp(search, "g"), replace);
+  } else {
+    userAgent = override;
+  }
+  gBuiltUAs.set(override, userAgent);
+  return userAgent;
+}
+
+function buildOverrides() {
+  gOverrides.clear();
+  gOverrideForHostCache.clear();
+
+  if (!Services.prefs.getBoolPref(PREF_OVERRIDES_ENABLED))
+    return;
+
+  let builtUAs = new Map;
+  let domains = gPrefBranch.getChildList("");
+
+  for (let domain of domains) {
+    let override = gPrefBranch.getCharPref(domain);
+    let userAgent = getUserAgentFromOverride(override);
+
+    if (userAgent != DEFAULT_UA) {
+      gOverrides.set(domain, userAgent);
+    }
+  }
+}
+
+function HTTP_on_useragent_request(aSubject, aTopic, aData) {
+  let channel = aSubject.QueryInterface(Ci.nsIHttpChannel);
+
+  for (let callback of gOverrideFunctions) {
+    let modifiedUA = callback(channel, DEFAULT_UA);
+    if (modifiedUA) {
+      channel.setRequestHeader("User-Agent", modifiedUA, false);
+      return;
+    }
+  }
+}

--- a/jsscripts/UserAgentUpdates.jsm
+++ b/jsscripts/UserAgentUpdates.jsm
@@ -1,0 +1,284 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Ported from esr60 sha1 682b1ec3b2c92831a0ea97754ce4fdd00b9497ae
+// https://git.sailfishos.org/mirror/gecko-dev/blob/esr60/netwerk/protocol/http/UserAgentUpdates.jsm
+// With some esr78 compatibility changes applied.
+
+"use strict";
+
+var EXPORTED_SYMBOLS = ["UserAgentUpdates"];
+
+const { AppConstants } = ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
+const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+Cu.importGlobalProperties(["XMLHttpRequest"]);
+
+ChromeUtils.defineModuleGetter(
+  this, "FileUtils", "resource://gre/modules/FileUtils.jsm");
+
+ChromeUtils.defineModuleGetter(
+  this, "NetUtil", "resource://gre/modules/NetUtil.jsm");
+
+ChromeUtils.defineModuleGetter(
+  this, "OS", "resource://gre/modules/osfile.jsm");
+
+
+ChromeUtils.defineModuleGetter(
+  this, "UpdateUtils", "resource://gre/modules/UpdateUtils.jsm");
+
+XPCOMUtils.defineLazyServiceGetter(
+  this, "gUpdateTimer", "@mozilla.org/updates/timer-manager;1", "nsIUpdateTimerManager");
+
+XPCOMUtils.defineLazyGetter(this, "gApp",
+  function() {
+    return Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULAppInfo)
+                                            .QueryInterface(Ci.nsIXULRuntime);
+  });
+
+XPCOMUtils.defineLazyGetter(this, "gDecoder",
+  function() { return new TextDecoder(); }
+);
+
+XPCOMUtils.defineLazyGetter(this, "gEncoder",
+  function() { return new TextEncoder(); }
+);
+
+const TIMER_ID = "user-agent-updates-timer";
+
+const PREF_UPDATES = "general.useragent.updates.";
+const PREF_UPDATES_ENABLED = PREF_UPDATES + "enabled";
+const PREF_UPDATES_URL = PREF_UPDATES + "url";
+const PREF_UPDATES_INTERVAL = PREF_UPDATES + "interval";
+const PREF_UPDATES_RETRY = PREF_UPDATES + "retry";
+const PREF_UPDATES_TIMEOUT = PREF_UPDATES + "timeout";
+const PREF_UPDATES_LASTUPDATED = PREF_UPDATES + "lastupdated";
+
+const KEY_PREFDIR = "PrefD";
+const KEY_APPDIR = "XCurProcD";
+const FILE_UPDATES = "ua-update.json";
+
+const PREF_APP_DISTRIBUTION = "distribution.id";
+const PREF_APP_DISTRIBUTION_VERSION = "distribution.version";
+
+var gInitialized = false;
+
+function readChannel(url) {
+  return new Promise((resolve, reject) => {
+    try {
+      let channel = NetUtil.newChannel({uri: url, loadUsingSystemPrincipal: true});
+      channel.contentType = "application/json";
+
+      NetUtil.asyncFetch(channel, (inputStream, status) => {
+        if (!Components.isSuccessCode(status)) {
+          reject();
+          return;
+        }
+
+        let data = JSON.parse(
+          NetUtil.readInputStreamToString(inputStream, inputStream.available())
+        );
+        resolve(data);
+      });
+    } catch (ex) {
+      reject(new Error("UserAgentUpdates: Could not fetch " + url + " " +
+                       ex + "\n" + ex.stack));
+    }
+  });
+}
+
+var UserAgentUpdates = {
+  init: function(callback) {
+    if (gInitialized) {
+      return;
+    }
+    gInitialized = true;
+
+    this._callback = callback;
+    this._lastUpdated = 0;
+    this._applySavedUpdate();
+
+    Services.prefs.addObserver(PREF_UPDATES, this);
+  },
+
+  uninit: function() {
+    if (!gInitialized) {
+      return;
+    }
+    gInitialized = false;
+    Services.prefs.removeObserver(PREF_UPDATES, this);
+  },
+
+  _applyUpdate: function(update) {
+    // Check pref again in case it has changed
+    if (update && this._getPref(PREF_UPDATES_ENABLED, false)) {
+      this._callback(update);
+    } else {
+      this._callback(null);
+    }
+  },
+
+  _applySavedUpdate: function() {
+    if (!this._getPref(PREF_UPDATES_ENABLED, false)) {
+      // remove previous overrides
+      this._applyUpdate(null);
+      return;
+    }
+    // try loading from profile dir, then from app dir
+    let dirs = [KEY_PREFDIR, KEY_APPDIR];
+
+    dirs.reduce((prevLoad, dir) => {
+      let file = FileUtils.getFile(dir, [FILE_UPDATES], true).path;
+      // tryNext returns promise to read file under dir and parse it
+      let tryNext = () => OS.File.read(file).then(
+        (bytes) => {
+          let update = JSON.parse(gDecoder.decode(bytes));
+          if (!update) {
+            throw new Error("invalid update");
+          }
+          return update;
+        }
+      );
+      // try to load next one if the previous load failed
+      return prevLoad ? prevLoad.catch(tryNext) : tryNext();
+    }, null).catch((ex) => {
+      if (AppConstants.platform !== "android") {
+        // All previous (non-Android) load attempts have failed, so we bail.
+        throw new Error("UserAgentUpdates: Failed to load " + FILE_UPDATES +
+                         ex + "\n" + ex.stack);
+      }
+      // Make one last attempt to read from the Fennec APK root.
+      return readChannel("resource://android/" + FILE_UPDATES);
+    }).then((update) => {
+      // Apply update if loading was successful
+      this._applyUpdate(update);
+    }).catch(Cu.reportError);
+    this._scheduleUpdate();
+  },
+
+  _saveToFile: function(update) {
+    let file = FileUtils.getFile(KEY_PREFDIR, [FILE_UPDATES], true);
+    let path = file.path;
+    let bytes = gEncoder.encode(JSON.stringify(update));
+    OS.File.writeAtomic(path, bytes, {tmpPath: path + ".tmp"}).then(
+      () => {
+        this._lastUpdated = Date.now();
+        Services.prefs.setCharPref(
+          PREF_UPDATES_LASTUPDATED, this._lastUpdated.toString());
+      },
+      Cu.reportError
+    );
+  },
+
+  _getPref: function(name, def) {
+    try {
+      switch (typeof def) {
+        case "number": return Services.prefs.getIntPref(name);
+        case "boolean": return Services.prefs.getBoolPref(name);
+      }
+      return Services.prefs.getCharPref(name);
+    } catch (e) {
+      return def;
+    }
+  },
+
+  _getParameters() {
+    return {
+      "%DATE%": function() { return Date.now().toString(); },
+      "%PRODUCT%": function() { return gApp.name; },
+      "%APP_ID%": function() { return gApp.ID; },
+      "%APP_VERSION%": function() { return gApp.version; },
+      "%BUILD_ID%": function() { return gApp.appBuildID; },
+      "%OS%": function() { return gApp.OS; },
+      "%CHANNEL%": function() { return UpdateUtils.UpdateChannel; },
+      "%DISTRIBUTION%": function() { return this._getPref(PREF_APP_DISTRIBUTION, ""); },
+      "%DISTRIBUTION_VERSION%": function() { return this._getPref(PREF_APP_DISTRIBUTION_VERSION, ""); },
+    };
+  },
+
+  _getUpdateURL: function() {
+    let url = this._getPref(PREF_UPDATES_URL, "");
+    let params = this._getParameters();
+    return url.replace(/%[A-Z_]+%/g, function(match) {
+      let param = params[match];
+      // preserve the %FOO% string (e.g. as an encoding) if it's not a valid parameter
+      return param ? encodeURIComponent(param()) : match;
+    });
+  },
+
+  _fetchUpdate: function(url, success, error) {
+    let request = new XMLHttpRequest();
+    request.mozBackgroundRequest = true;
+    request.timeout = this._getPref(PREF_UPDATES_TIMEOUT, 60000);
+    request.open("GET", url, true);
+    request.overrideMimeType("application/json");
+    request.responseType = "json";
+
+    request.addEventListener("load", function() {
+      let response = request.response;
+      response ? success(response) : error();
+    });
+    request.addEventListener("error", error);
+    request.send();
+  },
+
+  _update: function() {
+    let url = this._getUpdateURL();
+    url && this._fetchUpdate(url,
+      response => { // success
+        // apply update and save overrides to profile
+        this._applyUpdate(response);
+        this._saveToFile(response);
+        this._scheduleUpdate(); // cancel any retries
+      },
+      response => { // error
+        this._scheduleUpdate(true /* retry */);
+      });
+  },
+
+  _scheduleUpdate: function(retry) {
+    // only schedule updates in the main process
+    if (gApp.processType !== Ci.nsIXULRuntime.PROCESS_TYPE_DEFAULT) {
+      return;
+    }
+    let interval = this._getPref(PREF_UPDATES_INTERVAL, 604800 /* 1 week */);
+    if (retry) {
+      interval = this._getPref(PREF_UPDATES_RETRY, interval);
+    }
+    gUpdateTimer.registerTimer(TIMER_ID, this, Math.max(1, interval));
+  },
+
+  notify: function(timer) {
+    // timer notification
+    if (this._getPref(PREF_UPDATES_ENABLED, false)) {
+      this._update();
+    }
+  },
+
+  observe: function(subject, topic, data) {
+    switch (topic) {
+      case "nsPref:changed":
+        if (data === PREF_UPDATES_ENABLED) {
+          this._applySavedUpdate();
+        } else if (data === PREF_UPDATES_INTERVAL) {
+          this._scheduleUpdate();
+        } else if (data === PREF_UPDATES_LASTUPDATED) {
+          // reload from file if there has been an update
+          let lastUpdated = parseInt(
+            this._getPref(PREF_UPDATES_LASTUPDATED, "0"), 0);
+          if (lastUpdated > this._lastUpdated) {
+            this._applySavedUpdate();
+            this._lastUpdated = lastUpdated;
+          }
+        }
+        break;
+    }
+  },
+
+  QueryInterface: ChromeUtils.generateQI([
+    Ci.nsIObserver,
+    Ci.nsITimerCallback,
+  ]),
+};

--- a/link_to_system.sh
+++ b/link_to_system.sh
@@ -57,6 +57,8 @@ mkdir -p $TARGET_DIR/chrome/embedlite/content/sync;
 mkdir -p $TARGET_DIR/chrome/embedlite/content/search-plugins;
 ln -s $(pwd)/jsscripts/embedhelper.js $TARGET_DIR/chrome/embedlite/content/embedhelper.js;
 ln -s $(pwd)/jsscripts/OrientationChangeHandler.jsm $TARGET_DIR/chrome/embedlite/content/OrientationChangeHandler.jsm;
+ln -s $(pwd)/jsscripts/UserAgentUpdates.jsm $TARGET_DIR/chrome/embedlite/content/UserAgentUpdates.jsm;
+ln -s $(pwd)/jsscripts/UserAgentOverrides.jsm $TARGET_DIR/chrome/embedlite/content/UserAgentOverrides.jsm;
 ln -s $(pwd)/jsscripts/Prompt.jsm $TARGET_DIR/chrome/embedlite/content/Prompt.jsm;
 ln -s $(pwd)/jsscripts/SelectAsyncHelper.js $TARGET_DIR/chrome/embedlite/content/SelectAsyncHelper.js;
 ln -s $(pwd)/jsscripts/SelectionHandler.js $TARGET_DIR/chrome/embedlite/content/SelectionHandler.js;


### PR DESCRIPTION
UserAgentOverrides.jsm was removed from gecko-dev
https://bugzilla.mozilla.org/show_bug.cgi?id=1513574

We still rely on this to allow per-uri UA overrides to be provided.
This commit moves the esr60 version of UserAgentOverrides.jsm
and UserAgentUpdates.jsm into embedlite-components, and then updates
them slightly to align with esr78 changes.