### PR TITLE
[embedlite-components] Replace uses of URI only permissions API. JB#56082 OMP#JOLLA-485

### DIFF
--- a/jscomps/ContentPermissionManager.js
+++ b/jscomps/ContentPermissionManager.js
@@ -56,9 +56,8 @@ ContentPermissionManager.prototype = {
               break;
           case "get-all-for-uri":
               let result = [];
-              let permissions = Services.perms.getAllForURI(Services.io.newURI(data.uri, null, null));
-              while (permissions.hasMoreElements()) {
-                  let permission = permissions.getNext().QueryInterface(Ci.nsIPermission);
+              let permissions = Services.perms.getAllForPrincipal(Services.scriptSecurityManager.createContentPrincipal(Services.io.newURI(data.uri, null, null), {}));
+              for (let permission of permissions) {
                   result.push({
                                   type: permission.type,
                                   uri: data.uri,

--- a/jscomps/EmbedLiteChromeManager.js
+++ b/jscomps/EmbedLiteChromeManager.js
@@ -98,16 +98,15 @@ EmbedLiteChromeListener.prototype = {
       message["type"] = event.type;
       break;
     case "DOMPopupBlocked":
-      let permissions = Services.perms.getAllForURI(Services.io.newURI(event.target.URL, null, null));
-      while (permissions.hasMoreElements()) {
-        let permission = permissions.getNext().QueryInterface(Ci.nsIPermission);
+      let permissions = Services.perms.getAllForPrincipal(Services.scriptSecurityManager.createContentPrincipal(event.popupWindowURI, {}));
+      for (let permission of permissions) {
         if (permission.type == "popup" && permission.capability == Ci.nsIPermissionManager.DENY_ACTION) {
           // Ignore popup
           return;
         }
       }
       messageName = "embed:popupblocked";
-      message["host"] = event.target.URL;
+      message["host"] = event.popupWindowURI.displaySpec;
       break;
     }
 


### PR DESCRIPTION
The DOMPopupBlocked event supplies a URI and not a directly derived
principal so it is still URI based just with the extra step of
constructing a principal from the URI to passed to getAllForPrincipal.

In ContentPermissionPrompt.js a principal is available from the source
but this gets fed through C++ models in sailfish-components-webview and
the limited representation means reducing it to an origin URI and the
constructing a new content principal on use.