### PR TITLE
Pass private browsing status when requesting permissions. JB#55925 OMP#JOLLA-445

### DIFF
--- a/jscomps/ContentPermissionPrompt.js
+++ b/jscomps/ContentPermissionPrompt.js
@@ -9,6 +9,9 @@ const Cc = Components.classes;
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
+ChromeUtils.defineModuleGetter(this, "PrivateBrowsingUtils",
+                               "resource://gre/modules/PrivateBrowsingUtils.jsm");
+
 XPCOMUtils.defineLazyServiceGetter(Services, "embedlite",
                                     "@mozilla.org/embedlite-app-service;1",
                                     "nsIEmbedAppService");
@@ -30,6 +33,20 @@ ContentPermissionPrompt.prototype = {
 
   _getReqKey: function(request, type) {
     return request.principal.URI.host + " " + type;
+  },
+
+  // Whether we are in private browsing mode
+  _getInPrivateBrowsing: function(window) {
+    if (window) {
+      return PrivateBrowsingUtils.isContentWindowPrivate(window);
+    }
+    // Assume that we're in private browsing mode if the caller did
+    // not provide a window.  The callers which really care about this
+    // will indeed pass down a window to us, and for those who don't,
+    // we can just assume that we don't want to save the entered
+    // permission information.
+    this.log("We have no chromeWindow so assume we're in a private context");
+    return true;
   },
 
   handleExistingPermission: function handleExistingPermission(request, type) {
@@ -66,22 +83,32 @@ ContentPermissionPrompt.prototype = {
     Services.embedlite.removeMessageListener("embedui:permissions", this);
     let entityName = kEntities[perm.type];
     if (ret.allow) {
-      // If the user checked "Don't ask again", make a permanent exception
-      if (ret.checkedDontAsk) {
-        Services.perms.addFromPrincipal(request.principal, perm.type, Ci.nsIPermissionManager.ALLOW_ACTION);
-      } else {
-        Services.perms.addFromPrincipal(request.principal, perm.type, Ci.nsIPermissionManager.ALLOW_ACTION,
-                                        Ci.nsIPermissionManager.EXPIRE_SESSION);
+      // When in private browing, even session storage is skipped to avoid the
+      // decision leaking into normal browsing mode
+      if (!this._getInPrivateBrowsing(request.window)) {
+        // If the user checked "Don't ask again", make a permanent exception
+        if (ret.checkedDontAsk) {
+          Services.perms.addFromPrincipal(request.principal, perm.type, Ci.nsIPermissionManager.ALLOW_ACTION);
+        } else {
+          Services.perms.addFromPrincipal(request.principal, perm.type, Ci.nsIPermissionManager.ALLOW_ACTION,
+                                          Ci.nsIPermissionManager.EXPIRE_SESSION);
+        }
       }
+      // Allow the request in this case, whether in normal or private browing mode
       cachedreqs.forEach(function(r) { r.allow(); });
     } else {
-      // If the user checked "Don't ask again", make a permanent exception
-      if (ret.checkedDontAsk) {
-        Services.perms.addFromPrincipal(request.principal, perm.type, Ci.nsIPermissionManager.DENY_ACTION);
-      } else {
-        Services.perms.addFromPrincipal(request.principal, perm.type, Ci.nsIPermissionManager.DENY_ACTION,
-                                        Ci.nsIPermissionManager.EXPIRE_SESSION);
+      // When in private browing, even session storage is skipped to avoid the
+      // decision leaking into normal browsing mode
+      if (!this._getInPrivateBrowsing(request.window)) {
+        // If the user checked "Don't ask again", make a permanent exception
+        if (ret.checkedDontAsk) {
+          Services.perms.addFromPrincipal(request.principal, perm.type, Ci.nsIPermissionManager.DENY_ACTION);
+        } else {
+          Services.perms.addFromPrincipal(request.principal, perm.type, Ci.nsIPermissionManager.DENY_ACTION,
+                                          Ci.nsIPermissionManager.EXPIRE_SESSION);
+        }
       }
+      // Cancel the request in this case, whether in normal or private browing mode
       cachedreqs.forEach(function(r) { r.cancel(); });
     }
     delete this._pendingRequests[ret.id];
@@ -121,7 +148,8 @@ ContentPermissionPrompt.prototype = {
       Services.embedlite.sendAsyncMessage(winId, "embed:permissions",
                                           JSON.stringify({title: entityName,
                                                           host: request.principal.URI.host,
-                                                          id: reqkey}));
+                                                          id: reqkey,
+                                                          privateBrowsing: this._getInPrivateBrowsing(request.window)}));
     } catch (e) {
       Logger.warn("ContentPermissionPrompt: sending async message failed", e)
     }


### PR DESCRIPTION
When in private browsing mode, it shouldn't be possible to permanently record permissions, since this would leak location information.

This change passes the status of private browsing to the UI so that it can disable the option to save permission info when in private browsing mode.