### PR TITLE
Update to new nsITypeAheadFind interface. Fixes JB#56261 OMP#JOLLA-521

### DIFF
--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -200,19 +200,17 @@ EmbedHelper.prototype = {
           return;
         }
 
+        let result = null;
         if (!this._finder) {
           const {Finder} = ChromeUtils.import("resource://gre/modules/Finder.jsm", {});
           this._finder = new Finder(docShell);
-          this._finder.fastFind(searchText, false, true);
+          result = this._finder.fastFind(searchText, false, true);
         } else if (!searchAgain) {
-          this._finder.fastFind(searchText, false, true);
+          result = this._finder.fastFind(searchText, false, true);
         } else {
-          this._finder.findAgain(searchBackwards, false, true);
+          result = this._finder.findAgain(searchText, searchBackwards, false, true);
         }
-
-        // Hackish way to abusing internals of Finder.
-        // We should implement FinderHelper (JB#53008).
-        sendAsyncMessage("embed:find", { r: this._finder._lastFindResult });
+        sendAsyncMessage("embed:find", { r: result.result });
         break;
       }
       case "Viewport:Change": {


### PR DESCRIPTION
Updates embedhelper.js to use the new `nsITypeAheadFind` interface, so that in-page search works again. The new interface is slightly cleaner, since the results are returned as the return values to the functions (rather than having to access an internal variable of Finder.js).