### PR TITLE
[embedlite-components] Fix TLS certificate error page. JB#56093 OMP#JOLLA-491

### DIFF
--- a/jscomps/AboutRedirector.js
+++ b/jscomps/AboutRedirector.js
@@ -58,13 +58,11 @@ AboutRedirector.prototype = {
     return flags | Ci.nsIAboutModule.ALLOW_SCRIPT;
   },
 
-  newChannel: function(aURI) {
+  newChannel: function(aURI, aLoadInfo) {
     let moduleInfo = this._getModuleInfo(aURI);
 
-    var ios = Cc["@mozilla.org/network/io-service;1"].
-              getService(Ci.nsIIOService);
-
-    var channel = ios.newChannel(moduleInfo.uri, null, null);
+    let pageURI = Services.io.newURI(moduleInfo.uri);
+    var channel = Services.io.newChannelFromURIWithLoadInfo(pageURI, aLoadInfo);
 
     if (!moduleInfo.privileged) {
       // Setting the owner to null means that we'll go through the normal

--- a/jscomps/EmbedLiteErrorPageHandler.js
+++ b/jscomps/EmbedLiteErrorPageHandler.js
@@ -29,11 +29,13 @@ function EventLinkListener(aWindow)
 {
   this._winID = Services.embedlite.getIDByWindow(aWindow);
   this._targetWindow = Services.embedlite.getContentWindowByID(this._winID);
+  this._docShell = aWindow.docShell
 }
 
 EventLinkListener.prototype = {
   _winID: -1,
   _targetWindow: null,
+  _docShell: null,
   handleEvent: function Input_handleEvent(aEvent) {
     switch (aEvent.type) {
       case "DOMContentLoaded": {
@@ -44,6 +46,7 @@ EventLinkListener.prototype = {
         // pages have any privilege themselves.
         if (/^about:/.test(target.documentURI)) {
           ErrorPageEventHandler._targetWindow = this._targetWindow;
+          ErrorPageEventHandler._docShell = this._docShell;
           Services.embedlite.chromeEventHandler(this._targetWindow).addEventListener("click", ErrorPageEventHandler, true);
           let listener = function() {
             try {
@@ -54,6 +57,7 @@ EventLinkListener.prototype = {
               Services.embedlite.chromeEventHandler(this._targetWindow).removeEventListener("pagehide", listener, true);
             } catch (e) {}
             ErrorPageEventHandler._targetWindow = null;
+            ErrorPageEventHandler._docShell = null;
           }.bind(this);
 
           Services.embedlite.chromeEventHandler(this._targetWindow).addEventListener("pagehide", listener, true);
@@ -118,6 +122,7 @@ EmbedLiteErrorPageHandler.prototype = {
 
 var ErrorPageEventHandler = {
   _targetWindow: null,
+  _docShell: null,
   handleEvent: function(aEvent) {
     switch (aEvent.type) {
       case "click": {
@@ -135,20 +140,26 @@ var ErrorPageEventHandler = {
           let temp = errorDoc.getElementById("temporaryExceptionButton");
           if (target == temp || target == perm) {
             // Handle setting an cert exception and reloading the page
-            try {
-              // Add a new SSL exception for this URL
-              let uri = Services.io.newURI(errorDoc.location.href, null, null);
-              let sslExceptions = new SSLExceptions();
-
-              if (target == perm) {
-                sslExceptions.addPermanentException(uri, errorDoc.defaultView, this._targetWindow);
-              }
-              else {
-                sslExceptions.addTemporaryException(uri, errorDoc.defaultView, this._targetWindow);
-              }
-            } catch (e) {
-              dump("Failed to set cert exception: " + e + "\n");
+            let uri = Services.io.newURI(errorDoc.location.href);
+            let securityInfo = this._docShell.failedChannel.securityInfo;
+            securityInfo.QueryInterface(Ci.nsITransportSecurityInfo);
+            let cert = securityInfo.serverCert;
+            let overrideService = Cc["@mozilla.org/security/certoverride;1"]
+                                    .getService(Ci.nsICertOverrideService);
+            let flags = 0;
+            if (securityInfo.isUntrusted) {
+              flags |= overrideService.ERROR_UNTRUSTED;
             }
+            if (securityInfo.isDomainMismatch) {
+              flags |= overrideService.ERROR_MISMATCH;
+            }
+            if (securityInfo.isNotValidAtThisTime) {
+              flags |= overrideService.ERROR_TIME;
+            }
+            let temporary = (target == temp) ||
+                             PrivateBrowsingUtils.isWindowPrivate(errorDoc.defaultView);
+            overrideService.rememberValidityOverride(uri.asciiHost, uri.port, cert, flags,
+                                                     temporary);
             errorDoc.location.reload();
           } else if (target == errorDoc.getElementById("getMeOutOfHereButton")) {
             errorDoc.location = "about:home";
@@ -160,111 +171,5 @@ var ErrorPageEventHandler = {
   }
 };
 
-/**
-  A class to add exceptions to override SSL certificate problems. The functionality
-  itself is borrowed from exceptionDialog.js.
-*/
-function SSLExceptions() {
-  this._overrideService = Cc["@mozilla.org/security/certoverride;1"]
-                          .getService(Ci.nsICertOverrideService);
-}
-
-
-SSLExceptions.prototype = {
-  _overrideService: null,
-  _sslStatus: null,
-
-  getInterface: function SSLE_getInterface(aIID) {
-    return this.QueryInterface(aIID);
-  },
-  QueryInterface: function SSLE_QueryInterface(aIID) {
-    if (aIID.equals(Ci.nsIBadCertListener2) ||
-        aIID.equals(Ci.nsISupports))
-      return this;
-
-    throw Components.results.NS_ERROR_NO_INTERFACE;
-  },
-
-  /**
-    To collect the SSL status we intercept the certificate error here
-    and store the status for later use.
-  */
-  notifyCertProblem: function SSLE_notifyCertProblem(socketInfo, sslStatus, targetHost) {
-    this._sslStatus = sslStatus.QueryInterface(Ci.nsISSLStatus);
-    return true; // suppress error UI
-  },
-
-  /**
-    Attempt to download the certificate for the location specified to get the SSLState
-    for the certificate and the errors.
-   */
-  _checkCert: function SSLE_checkCert(aURI, aWindow) {
-    this._sslStatus = null;
-
-    dump("Check server Cert:" + aURI.prePath + "\n");
-    let req = new aWindow.XMLHttpRequest();
-    try {
-      if (aURI) {
-        req.open("GET", aURI.prePath, false);
-        req.channel.notificationCallbacks = this;
-        req.send(null);
-      }
-    } catch (e) {
-      // We *expect* exceptions if there are problems with the certificate
-      // presented by the site.  Log it, just in case, but we can proceed here,
-      // with appropriate sanity checks
-      Components.utils.reportError("Attempted to connect to a site with a bad certificate in the add exception dialog. " +
-                                   "This results in a (mostly harmless) exception being thrown. " +
-                                   "Logged for information purposes only: " + e);
-    }
-
-    return this._sslStatus;
-  },
-
-  /**
-    Internal method to create an override.
-  */
-  _addOverride: function SSLE_addOverride(aURI, aWindow, aTargetWindow, aTemporary) {
-    let SSLStatus = this._checkCert(aURI, aTargetWindow);
-    let certificate = SSLStatus.serverCert;
-
-    let flags = 0;
-
-    // in private browsing do not store exceptions permanently ever
-    if (PrivateBrowsingUtils.isWindowPrivate(aWindow)) {
-      aTemporary = true;
-    }
-
-    if (SSLStatus.isUntrusted)
-      flags |= this._overrideService.ERROR_UNTRUSTED;
-    if (SSLStatus.isDomainMismatch)
-      flags |= this._overrideService.ERROR_MISMATCH;
-    if (SSLStatus.isNotValidAtThisTime)
-      flags |= this._overrideService.ERROR_TIME;
-
-    this._overrideService.rememberValidityOverride(
-      aURI.asciiHost,
-      aURI.port,
-      certificate,
-      flags,
-      aTemporary);
-  },
-
-  /**
-    Creates a permanent exception to override all overridable errors for
-    the given URL.
-  */
-  addPermanentException: function SSLE_addPermanentException(aURI, aWindow, aTargetWindow) {
-    this._addOverride(aURI, aWindow, aTargetWindow, false);
-  },
-
-  /**
-    Creates a temporary exception to override all overridable errors for
-    the given URL.
-  */
-  addTemporaryException: function SSLE_addTemporaryException(aURI, aWindow, aTargetWindow) {
-    this._addOverride(aURI, aWindow, aTargetWindow, true);
-  }
-};
 
 this.NSGetFactory = XPCOMUtils.generateNSGetFactory([EmbedLiteErrorPageHandler]);


### PR DESCRIPTION
Fix AboutRedirector to use the up to date newChannel() function
signature and use Services.io.newChannelFromURIWithLoadInfo() instead of
newChannel() the call to which was failing because it required
additional arguments.

Then fix EmbedLiteErrorPageHandler to remove the use of the
nsIBadCertListener2 interface which no longer exists by porting the
changes from https://phabricator.services.mozilla.com/D21791.