### PR TITLE
[embedlite-components] Broadcast media types used for WebRTC. JB#56332

### DIFF
--- a/jscomps/EmbedLiteWebrtcUI.js
+++ b/jscomps/EmbedLiteWebrtcUI.js
@@ -17,6 +17,9 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
 XPCOMUtils.defineLazyModuleGetter(this, "Services",
                                   "resource://gre/modules/Services.jsm");
+XPCOMUtils.defineLazyServiceGetter(this, "MediaManagerService",
+                                   "@mozilla.org/mediaManagerService;1",
+                                   "nsIMediaManagerService");
 
 Services.scriptloader.loadSubScript("chrome://embedlite/content/Logger.js");
 
@@ -267,6 +270,7 @@ EmbedLiteWebrtcUI.prototype = {
         Services.obs.addObserver(this, "getUserMedia:ask-device-permission", false);
         Services.obs.addObserver(this, "getUserMedia:request", false);
         Services.obs.addObserver(this, "PeerConnection:request", false);
+        Services.obs.addObserver(this, "recording-device-events", false);
         break;
 
       case "getUserMedia:ask-device-permission":
@@ -302,6 +306,26 @@ EmbedLiteWebrtcUI.prototype = {
           aSubject.callID
         );
         break;
+
+      case "recording-device-events":
+        let windows = MediaManagerService.activeMediaCaptureWindows;
+        let webrtcMediaInfo = { "video": false, "audio": false};
+
+        for (let i = 0; i < windows.length; i++) {
+          let win = windows.queryElementAt(i, Ci.nsIDOMWindow);
+          let hasCamera = {};
+          let hasMicrophone = {};
+
+          MediaManagerService.mediaCaptureWindowState(win, hasCamera, hasMicrophone);
+          if (hasCamera.value != MediaManagerService.STATE_NOCAPTURE)
+            webrtcMediaInfo.video = true;
+          if (hasMicrophone.value != MediaManagerService.STATE_NOCAPTURE)
+            webrtcMediaInfo.audio = true;
+        }
+
+        let info = JSON.stringify(webrtcMediaInfo)
+        debug("devices in use: " + info);
+        Services.obs.notifyObservers(null, "webrtc-media-info", info);
     }
   }
 };


### PR DESCRIPTION
The state of media devices is reported by the ObserverService:
    
    message: webrtc-media-info
    payload: {"audio":false,"video":false}