### PR TITLE
Fix username and password autocomplete. Fixes JB#56496 OMP#JOLLA-561

### DIFF
--- a/jsscripts/FormAssistant.js
+++ b/jsscripts/FormAssistant.js
@@ -132,7 +132,7 @@ FormAssistant.prototype = {
     // 1. user selections will "replace" the full contents of the field; and
     // 2. we avoid synchronous search of the login database on every keypress.
     if (aElement.form && !aElement.value) {
-      let foundLogins = this._loginManager.findLogins({}, hostname, actionUri, null);
+      let foundLogins = this._loginManager.findLogins(hostname, actionUri, null);
       for (let pos = 0; pos < foundLogins.length; pos++) {
         // Filter suggestions based on the current input
         // Do not show the value if it is the current one in the input field

--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -411,8 +411,9 @@ EmbedHelper.prototype = {
       }
       case "DOMAutoComplete":
       case "blur": {
-        // JB#55434
-        // LoginManagerChild.onUsernameInput(aEvent);
+        let form = aEvent.target;
+        let win = form.ownerDocument.defaultView;
+        LoginManagerChild.forWindow(win).onFieldAutoComplete(form, null);
         break;
       }
       case 'touchstart':


### PR DESCRIPTION
Applies two fixes:-

The first fixes password autocomplete: when a username for a previously stored login is entered into a username field, the password field for that login will be filled out automatically.

The second fixes usernames offered in the keyboard AutoFill bar: when the caret is in an empty username field on a page for which a login is know, the username is offered as an option in the keyboard suggestions bar.