### PR TITLE
[embedlite-components] Fix Form ownerDocument is undefined error. JB#56595 OMP#JOLLA-564

### DIFF
--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -9,6 +9,11 @@ const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("resource://gre/modules/Geometry.jsm");
 ChromeUtils.import("resource://gre/modules/FileUtils.jsm");
+ChromeUtils.defineModuleGetter(
+  this,
+  "LoginHelper",
+  "resource://gre/modules/LoginHelper.jsm"
+);
 
 let actorManagerChildAttached = false;
 
@@ -412,8 +417,13 @@ EmbedHelper.prototype = {
       case "DOMAutoComplete":
       case "blur": {
         let form = aEvent.target;
-        let win = form.ownerDocument.defaultView;
-        LoginManagerChild.forWindow(win).onFieldAutoComplete(form, null);
+        if (form.ownerDocument &&
+                ChromeUtils.getClassName(form) === "HTMLInputElement" &&
+                (form.hasBeenTypePassword ||
+                  LoginHelper.isUsernameFieldType(form))) {
+          let win = form.ownerDocument.defaultView;
+          LoginManagerChild.forWindow(win).onFieldAutoComplete(form, null);
+        }
         break;
       }
       case 'touchstart':


### PR DESCRIPTION
Check ownerDocument is not null before deferencing it along with the
other conditions which would cause LoginFormFactory.jsm to throw a
"createFromField requires a password or username field in a document"
error.