### PR TITLE
[embedlite-components] Populate the technical details of the certificate page. JB#56370 OMP#JOLLA-541

### DIFF
--- a/jscomps/EmbedLiteGlobalHelper.js
+++ b/jscomps/EmbedLiteGlobalHelper.js
@@ -9,6 +9,7 @@ const Cr = Components.results;
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 const { LoginManagerParent } = ChromeUtils.import("resource://gre/modules/LoginManagerParent.jsm");
+const { L10nRegistry, FileSource } = ChromeUtils.import("resource://gre/modules/L10nRegistry.jsm");
 
 // Touch the recipeParentPromise lazy getter so we don't get
 // `this._recipeManager is undefined` errors during tests.
@@ -28,6 +29,11 @@ Services.scriptloader.loadSubScript("chrome://embedlite/content/Logger.js");
 function EmbedLiteGlobalHelper()
 {
   ActorManagerParent.flush();
+
+  L10nRegistry.registerSource(new FileSource(
+                                  "0-mozembedlite",
+                                  ["en-US", "fi", "ru"],
+                                  "chrome://browser/content/localization/{locale}/"))
 
   Logger.debug("JSComp: EmbedLiteGlobalHelper.js loaded");
 }

--- a/overrides/Makefile.am
+++ b/overrides/Makefile.am
@@ -58,4 +58,34 @@ localebrowser_ru_manifest_DATA = \
 	ru/netError.dtd \
 	$(NULL)
 
+localizationbrowser_manifestdir=$(libdir)/mozembedlite/chrome/chrome/content/localization/en-US/browser
+localizationbrowser_manifest_DATA = \
+	en-US/aboutCertError.ftl \
+	$(NULL)
+
+localizationbrowser_fi_manifestdir=$(libdir)/mozembedlite/chrome/chrome/content/localization/fi/browser
+localizationbrowser_fi_manifest_DATA = \
+	fi/aboutCertError.ftl \
+	$(NULL)
+
+localizationbrowser_ru_manifestdir=$(libdir)/mozembedlite/chrome/chrome/content/localization/ru/browser
+localizationbrowser_ru_manifest_DATA = \
+	ru/aboutCertError.ftl \
+	$(NULL)
+
+localizationbranding_manifestdir=$(libdir)/mozembedlite/chrome/chrome/content/localization/en-US/branding
+localizationbranding_manifest_DATA = \
+	en-US/brand.ftl \
+	$(NULL)
+
+localizationbranding_fi_manifestdir=$(libdir)/mozembedlite/chrome/chrome/content/localization/fi/branding
+localizationbranding_fi_manifest_DATA = \
+	fi/brand.ftl \
+	$(NULL)
+
+localizationbranding_ru_manifestdir=$(libdir)/mozembedlite/chrome/chrome/content/localization/ru/branding
+localizationbranding_ru_manifest_DATA = \
+	ru/brand.ftl \
+	$(NULL)
+
 AM_CPPFLAGS = $(DEPS_CFLAGS)

--- a/overrides/aboutCertError.xhtml
+++ b/overrides/aboutCertError.xhtml
@@ -21,6 +21,8 @@
     <title>&certerror.pagetitle;</title>
     <meta name="viewport" content="width=device-width; user-scalable=false" />
     <link rel="stylesheet" href="chrome://global/skin/netError.css" type="text/css" media="all" />
+    <link rel="localization" href="browser/aboutCertError.ftl" />
+    <link rel="localization" href="branding/brand.ftl"/>
     <!-- This page currently uses the same favicon as neterror.xhtml.
          If the location of the favicon is changed for both pages, the
          FAVICON_ERRORPAGE_URL symbol in toolkit/components/places/src/nsFaviconService.h
@@ -39,27 +41,19 @@
       // which is the URL displayed in the location bar, i.e.
       // the URI that the user attempted to load.
 
-      function getCSSClass() {
-        var url = document.documentURI;
-        var matches = url.match(/s\=([^&]+)\&/);
-        // s is optional, if no match just return nothing
-        if (!matches || matches.length < 2)
-          return "";
+      const formatter = new Intl.DateTimeFormat("default");
+      let searchParams = new URLSearchParams(document.documentURI.split("?")[1]);
 
-        // parenthetical match is the second entry
-        return decodeURIComponent(matches[1]);
+      function getErrorCode() {
+        return searchParams.get("e");
+      }
+
+      function getCSSClass() {
+        return searchParams.get("s");
       }
 
       function getDescription() {
-        var url = document.documentURI;
-        var desc = url.search(/d\=/);
-
-        // desc == -1 if not found; if so, return an empty string
-        // instead of what would turn out to be portions of the URI
-        if (desc == -1)
-          return "";
-
-        return decodeURIComponent(url.slice(desc + 2));
+        return searchParams.get("d");
       }
 
       function initPage() {
@@ -88,113 +82,190 @@
         if (getCSSClass() == "badStsCert" || window != top)
           document.getElementById("expertContent").setAttribute("hidden", "true");
 
-        var tech = document.getElementById("technicalContentText");
-        if (tech)
-          tech.textContent = getDescription();
-
-        addDomainErrorLinks();
+        setTechnicalDetailsOnCertError();
       }
 
-      /* Try to preserve the links contained in the error description, like
-         the error code.
+      async function setTechnicalDetailsOnCertError() {
+        let technicalInfo = document.getElementById("technicalContentText");
 
-         Also, in the case of SSL error pages about domain mismatch, see if
-         we can hyperlink the user to the correct site.  We don't want
-         to do this generically since it allows MitM attacks to redirect
-         users to a site under attacker control, but in certain cases
-         it is safe (and helpful!) to do so.  Bug 402210
-      */
-      function addDomainErrorLinks() {
-        // Rather than textContent, we need to treat description as HTML
-        var sd = document.getElementById("technicalContentText");
-        if (sd) {
-          var desc = getDescription();
-
-          // sanitize description text - see bug 441169
-
-          // First, find the index of the <a> tags we care about, being
-          // careful not to use an over-greedy regex.
-          var codeRe = /<a id="errorCode" title="([^"]+)">/;
-          var codeResult = codeRe.exec(desc);
-          var domainRe = /<a id="cert_domain_link" title="([^"]+)">/;
-          var domainResult = domainRe.exec(desc);
-
-          // The order of these links in the description is fixed in
-          // TransportSecurityInfo.cpp:formatOverridableCertErrorMessage.
-          var firstResult = domainResult;
-          if (!domainResult)
-            firstResult = codeResult;
-          if (!firstResult)
-            return;
-
-          // Remove sd's existing children
-          sd.textContent = "";
-
-          // Everything up to the first link should be text content.
-          sd.appendChild(document.createTextNode(desc.slice(0, firstResult.index)));
-
-          // Now create the actual links.
-          if (domainResult) {
-            createLink(sd, "cert_domain_link", domainResult[1]);
-            // Append text for anything between the two links.
-            sd.appendChild(document.createTextNode(desc.slice(desc.indexOf("</a>") + "</a>".length, codeResult.index)));
+        function setL10NLabel(l10nId, args = {}, attrs = {}, rewrite = true) {
+          let elem = document.createElement("label");
+          if (rewrite) {
+            technicalInfo.textContent = "";
           }
-          createLink(sd, "errorCode", codeResult[1]);
+          technicalInfo.appendChild(elem);
 
-          // Finally, append text for anything after the last closing </a>.
-          sd.appendChild(document.createTextNode(desc.slice(desc.lastIndexOf("</a>") + "</a>".length)));
+          let newLines = document.createTextNode("\n \n");
+          technicalInfo.appendChild(newLines);
+
+          if (attrs) {
+            let link = document.createElement("a");
+            for (let attr of Object.keys(attrs)) {
+              link.setAttribute(attr, attrs[attr]);
+            }
+            elem.appendChild(link);
+          }
+
+          if (args) {
+            document.l10n.setAttributes(elem, l10nId, args);
+          } else {
+            document.l10n.setAttributes(elem, l10nId);
+          }
         }
 
-        // Then initialize the cert domain link.
-        var link = document.getElementById("cert_domain_link");
-        if (!link)
-          return;
+        let cssClass = getCSSClass();
+        let error = getErrorCode();
 
-        var okHost = link.getAttribute("title");
-        var thisHost = document.location.hostname;
-        var proto = document.location.protocol;
+        let hostString = document.location.hostname;
+        let port = document.location.port;
+        if (port && port != 443) {
+          hostString += ":" + port;
+        }
 
-        // If okHost is a wildcard domain ("*.example.com") let's
-        // use "www" instead.  "*.example.com" isn't going to
-        // get anyone anywhere useful. bug 432491
-        okHost = okHost.replace(/^\*\./, "www.");
+        let l10nId;
+        let args = {
+          hostname: hostString,
+        };
+        let failedCertInfo = document.getFailedCertSecurityInfo();
+        if (failedCertInfo.isUntrusted) {
+          switch (failedCertInfo.errorCodeString) {
+            case "MOZILLA_PKIX_ERROR_MITM_DETECTED":
+              setL10NLabel("cert-error-mitm-intro");
+              setL10NLabel("cert-error-mitm-mozilla", {}, {}, false);
+              setL10NLabel("cert-error-mitm-connection", {}, {}, false);
+              break;
+            case "SEC_ERROR_UNKNOWN_ISSUER":
+              setL10NLabel("cert-error-trust-unknown-issuer-intro");
+              setL10NLabel("cert-error-trust-unknown-issuer", args, {}, false);
+              break;
+            case "SEC_ERROR_CA_CERT_INVALID":
+              setL10NLabel("cert-error-intro", args);
+              setL10NLabel("cert-error-trust-cert-invalid", {}, {}, false);
+              break;
+            case "SEC_ERROR_UNTRUSTED_ISSUER":
+              setL10NLabel("cert-error-intro", args);
+              setL10NLabel("cert-error-trust-untrusted-issuer", {}, {}, false);
+              break;
+            case "SEC_ERROR_CERT_SIGNATURE_ALGORITHM_DISABLED":
+              setL10NLabel("cert-error-intro", args);
+              setL10NLabel(
+                "cert-error-trust-signature-algorithm-disabled",
+                {},
+                {},
+                false
+              );
+              break;
+            case "SEC_ERROR_EXPIRED_ISSUER_CERTIFICATE":
+              setL10NLabel("cert-error-intro", args);
+              setL10NLabel("cert-error-trust-expired-issuer", {}, {}, false);
+              break;
+            case "MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT":
+              setL10NLabel("cert-error-intro", args);
+              setL10NLabel("cert-error-trust-self-signed", {}, {}, false);
+              break;
+            case "MOZILLA_PKIX_ERROR_ADDITIONAL_POLICY_CONSTRAINT_FAILED":
+              setL10NLabel("cert-error-intro", args);
+              setL10NLabel("cert-error-trust-symantec", {}, {}, false);
+              break;
+            default:
+              setL10NLabel("cert-error-intro", args);
+              setL10NLabel("cert-error-untrusted-default", {}, {}, false);
+          }
+        }
 
-        /* case #1:
-         * example.com uses an invalid security certificate.
-         *
-         * The certificate is only valid for www.example.com
-         *
-         * Make sure to include the "." ahead of thisHost so that
-         * a MitM attack on paypal.com doesn't hyperlink to "notpaypal.com"
-         *
-         * We'd normally just use a RegExp here except that we lack a
-         * library function to escape them properly (bug 248062), and
-         * domain names are famous for having '.' characters in them,
-         * which would allow spurious and possibly hostile matches.
-         */
-        if (okHost.endsWith("." + thisHost))
-          link.href = proto + okHost;
+        if (failedCertInfo.isDomainMismatch) {
+          let subjectAltNames = failedCertInfo.subjectAltNames.split(",");
+          subjectAltNames = subjectAltNames.filter(name => !!name.length);
+          let numSubjectAltNames = subjectAltNames.length;
 
-        /* case #2:
-         * browser.garage.maemo.org uses an invalid security certificate.
-         *
-         * The certificate is only valid for garage.maemo.org
-         */
-        if (thisHost.endsWith("." + okHost))
-          link.href = proto + okHost;
+          if (numSubjectAltNames != 0) {
+            if (numSubjectAltNames == 1) {
+              args["alt-name"] = subjectAltNames[0];
 
-        // If we set a link, meaning there's something helpful for
-        // the user here, expand the section by default
-        if (link.href && getCSSClass() != "expertBadCert")
-          toggle("technicalContent");
-      }
+              // Let's check if we want to make this a link.
+              let okHost = failedCertInfo.subjectAltNames;
+              let href = "";
+              let thisHost = document.location.hostname;
+              let proto = document.location.protocol + "//";
+              // If okHost is a wildcard domain ("*.example.com") let's
+              // use "www" instead.  "*.example.com" isn't going to
+              // get anyone anywhere useful. bug 432491
+              okHost = okHost.replace(/^\*\./, "www.");
+              /* case #1:
+               * example.com uses an invalid security certificate.
+               *
+               * The certificate is only valid for www.example.com
+               *
+               * Make sure to include the "." ahead of thisHost so that
+               * a MitM attack on paypal.com doesn't hyperlink to "notpaypal.com"
+               *
+               * We'd normally just use a RegExp here except that we lack a
+               * library function to escape them properly (bug 248062), and
+               * domain names are famous for having '.' characters in them,
+               * which would allow spurious and possibly hostile matches.
+               */
 
-      function createLink(el, id, text) {
-        var anchorEl = document.createElement("a");
-        anchorEl.setAttribute("id", id);
-        anchorEl.setAttribute("title", text);
-        anchorEl.appendChild(document.createTextNode(text));
-        el.appendChild(anchorEl);
+              if (okHost.endsWith("." + thisHost)) {
+                href = proto + okHost;
+              }
+              /* case #2:
+               * browser.garage.maemo.org uses an invalid security certificate.
+               *
+               * The certificate is only valid for garage.maemo.org
+               */
+              if (thisHost.endsWith("." + okHost)) {
+                href = proto + okHost;
+              }
+
+              // Set the link if we want it.
+              if (href) {
+                setL10NLabel("cert-error-domain-mismatch-single", args, {
+                  href,
+                  "data-l10n-name": "domain-mismatch-link",
+                  id: "cert_domain_link",
+                });
+              } else {
+                setL10NLabel("cert-error-domain-mismatch-single-nolink", args);
+              }
+            } else {
+              let names = subjectAltNames.join(", ");
+              args["subject-alt-names"] = names;
+              setL10NLabel("cert-error-domain-mismatch-multiple", args);
+            }
+          } else {
+            setL10NLabel("cert-error-domain-mismatch", { hostname: hostString });
+          }
+        }
+
+        if (failedCertInfo.isNotValidAtThisTime) {
+          let notBefore = failedCertInfo.validNotBefore;
+          let notAfter = failedCertInfo.validNotAfter;
+          args = {
+            hostname: hostString,
+          };
+          if (notBefore && Date.now() < notAfter) {
+            let notBeforeLocalTime = formatter.format(new Date(notBefore));
+            l10nId = "cert-error-not-yet-valid-now";
+            args["not-before-local-time"] = notBeforeLocalTime;
+          } else {
+            let notAfterLocalTime = formatter.format(new Date(notAfter));
+            l10nId = "cert-error-expired-now";
+            args["not-after-local-time"] = notAfterLocalTime;
+          }
+          setL10NLabel(l10nId, args);
+        }
+
+        setL10NLabel(
+          "cert-error-code-prefix-link",
+          { error: failedCertInfo.errorCodeString },
+          {
+            title: failedCertInfo.errorCodeString,
+            id: "errorCode",
+            "data-l10n-name": "error-code-link",
+            "data-telemetry-id": "error_code_link",
+          },
+          false
+        );
       }
 
       function toggle(id) {
@@ -234,12 +305,20 @@
         <!-- The following sections can be unhidden by default by setting the
              "browser.xul.error_pages.expert_bad_cert" pref to true -->
         <div id="technicalContent" collapsed="true">
-          <h2 class="expander" onclick="toggle('technicalContent');" id="technicalContentHeading">&certerror.technical.heading;</h2>
-          <p id="technicalContentText"/>
+          <h2 class="expander" onclick="toggle('technicalContent');" id="technicalContentHeading">
+            <span class="expander-caret"/>
+            &certerror.technical.heading;
+          </h2>
+          <div>
+            <p id="technicalContentText"/>
+          </div>
         </div>
 
         <div id="expertContent" collapsed="true">
-          <h2 class="expander" onclick="toggle('expertContent');" id="expertContentHeading">&certerror.expert.heading;</h2>
+          <h2 class="expander" onclick="toggle('expertContent');" id="expertContentHeading">
+            <span class="expander-caret"/>
+            &certerror.expert.heading;
+          </h2>
           <div>
             <p>&certerror.expert.content;</p>
             <p>&certerror.expert.contentPara2;</p>

--- a/overrides/en-US/aboutCertError.ftl
+++ b/overrides/en-US/aboutCertError.ftl
@@ -1,0 +1,126 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-intro = { $hostname } uses an invalid security certificate.
+
+cert-error-mitm-intro = Websites prove their identity via certificates, which are issued by certificate authorities.
+
+cert-error-mitm-mozilla = { -brand-short-name } is backed by the non-profit Mozilla, which administers a completely open certificate authority (CA) store. The CA store helps ensure that certificate authorities are following best practices for user security.
+
+cert-error-mitm-connection = { -brand-short-name } uses the Mozilla CA store to verify that a connection is secure, rather than certificates supplied by the user’s operating system. So, if an antivirus program or a network is intercepting a connection with a security certificate issued by a CA that is not in the Mozilla CA store, the connection is considered unsafe.
+
+cert-error-trust-unknown-issuer-intro = Someone could be trying to impersonate the site and you should not continue.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-trust-unknown-issuer = Websites prove their identity via certificates. { -brand-short-name } does not trust { $hostname } because its certificate issuer is unknown, the certificate is self-signed, or the server is not sending the correct intermediate certificates.
+
+cert-error-trust-cert-invalid = The certificate is not trusted because it was issued by an invalid CA certificate.
+
+cert-error-trust-untrusted-issuer = The certificate is not trusted because the issuer certificate is not trusted.
+
+cert-error-trust-signature-algorithm-disabled = The certificate is not trusted because it was signed using a signature algorithm that was disabled because that algorithm is not secure.
+
+cert-error-trust-expired-issuer = The certificate is not trusted because the issuer certificate has expired.
+
+cert-error-trust-self-signed = The certificate is not trusted because it is self-signed.
+
+cert-error-trust-symantec = Certificates issued by GeoTrust, RapidSSL, Symantec, Thawte, and VeriSign are no longer considered safe because these certificate authorities failed to follow security practices in the past.
+
+cert-error-untrusted-default = The certificate does not come from a trusted source.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-domain-mismatch = Websites prove their identity via certificates. { -brand-short-name } does not trust this site because it uses a certificate that is not valid for { $hostname }.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $alt-name (String) - Alternate domain name for which the cert is valid.
+cert-error-domain-mismatch-single = Websites prove their identity via certificates. { -brand-short-name } does not trust this site because it uses a certificate that is not valid for { $hostname }. The certificate is only valid for <a data-l10n-name="domain-mismatch-link">{ $alt-name }</a>.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $alt-name (String) - Alternate domain name for which the cert is valid.
+cert-error-domain-mismatch-single-nolink = Websites prove their identity via certificates. { -brand-short-name } does not trust this site because it uses a certificate that is not valid for { $hostname }. The certificate is only valid for { $alt-name }.
+
+# Variables:
+# $subject-alt-names (String) - Alternate domain names for which the cert is valid.
+cert-error-domain-mismatch-multiple = Websites prove their identity via certificates. { -brand-short-name } does not trust this site because it uses a certificate that is not valid for { $hostname }. The certificate is only valid for the following names: { $subject-alt-names }
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $not-after-local-time (Date) - Certificate is not valid after this time.
+cert-error-expired-now = Websites prove their identity via certificates, which are valid for a set time period. The certificate for { $hostname } expired on { $not-after-local-time }.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $not-before-local-time (Date) - Certificate is not valid before this time.
+cert-error-not-yet-valid-now = Websites prove their identity via certificates, which are valid for a set time period. The certificate for { $hostname } will not be valid until { $not-before-local-time }.
+
+# Variables:
+# $error (String) - NSS error code string that specifies type of cert error. e.g. unknown issuer, invalid cert, etc.
+cert-error-code-prefix-link = Error code: <a data-l10n-name="error-code-link">{ $error }</a>
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-symantec-distrust-description = Websites prove their identity via certificates, which are issued by certificate authorities. Most browsers no longer trust certificates issued by GeoTrust, RapidSSL, Symantec, Thawte, and VeriSign. { $hostname } uses a certificate from one of these authorities and so the website’s identity cannot be proven.
+
+cert-error-symantec-distrust-admin = You may notify the website’s administrator about this problem.
+
+# Variables:
+# $hasHSTS (Boolean) - Indicates whether HSTS header is present.
+cert-error-details-hsts-label = HTTP Strict Transport Security: { $hasHSTS }
+
+# Variables:
+# $hasHPKP (Boolean) - Indicates whether HPKP header is present.
+cert-error-details-key-pinning-label = HTTP Public Key Pinning: { $hasHPKP }
+
+cert-error-details-cert-chain-label = Certificate chain:
+
+open-in-new-window-for-csp-or-xfo-error = Open Site in New Window
+
+# Variables:
+# $hostname (String) - Hostname of the website blocked by csp or xfo error.
+csp-xfo-blocked-long-desc = To protect your security, { $hostname } will not allow { -brand-short-name } to display the page if another site has embedded it. To see this page, you need to open it in a new window.
+
+## Messages used for certificate error titles
+
+connectionFailure-title = Unable to connect
+deniedPortAccess-title = This address is restricted
+# "Hmm" is a sound made when considering or puzzling over something.
+# You don't have to include it in your translation if your language does not have a written word like this.
+dnsNotFound-title = Hmm. We’re having trouble finding that site.
+fileNotFound-title = File not found
+fileAccessDenied-title = Access to the file was denied
+generic-title = Oops.
+captivePortal-title = Log in to network
+# "Hmm" is a sound made when considering or puzzling over something.
+# You don't have to include it in your translation if your language does not have a written word like this.
+malformedURI-title = Hmm. That address doesn’t look right.
+netInterrupt-title = The connection was interrupted
+notCached-title = Document Expired
+netOffline-title = Offline mode
+contentEncodingError-title = Content Encoding Error
+unsafeContentType-title = Unsafe File Type
+netReset-title = The connection was reset
+netTimeout-title = The connection has timed out
+unknownProtocolFound-title = The address wasn’t understood
+proxyConnectFailure-title = The proxy server is refusing connections
+proxyResolveFailure-title = Unable to find the proxy server
+redirectLoop-title = The page isn’t redirecting properly
+unknownSocketType-title = Unexpected response from server
+nssFailure2-title = Secure Connection Failed
+csp-xfo-error-title = { -brand-short-name } Can’t Open This Page
+corruptedContentError-title = Corrupted Content Error
+remoteXUL-title = Remote XUL
+sslv3Used-title = Unable to Connect Securely
+inadequateSecurityError-title = Your connection is not secure
+blockedByPolicy-title = Blocked Page
+clockSkewError-title = Your Computer Clock is Wrong
+networkProtocolError-title = Network Protocol Error
+nssBadCert-title = Warning: Potential Security Risk Ahead
+nssBadCert-sts-title = Did Not Connect: Potential Security Issue
+certerror-mitm-title = Software is Preventing { -brand-short-name } From Safely Connecting to This Site

--- a/overrides/en-US/brand.ftl
+++ b/overrides/en-US/brand.ftl
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+## Firefox Brand
+##
+## Firefox must be treated as a brand, and kept in English.
+## It cannot be:
+## - Declined to adapt to grammatical case.
+## - Transliterated.
+## - Translated.
+##
+## Reference: https://www.mozilla.org/styleguide/communications/translation/
+
+-brand-short-name = Browser
+-brand-full-name = Sailfish Browser
+# This brand name can be used in messages where the product name needs to
+# remain unchanged across different versions (Nightly, Beta, etc.).
+-brand-product-name = Browser
+-vendor-short-name = Sailfish

--- a/overrides/fi/aboutCertError.ftl
+++ b/overrides/fi/aboutCertError.ftl
@@ -1,0 +1,126 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-intro = Sivuston { $hostname } tietoturvavarmenne ei ole kelvollinen.
+
+cert-error-mitm-intro = Sivustot todistavat identiteettinsä varmenteella, ja varmenteen myöntää varmentaja.
+
+cert-error-mitm-mozilla = { -brand-short-name }in tukena on voittoa tavoittelematon Mozilla, joka hallinnoi täysin avointa varmentajien (CA) säilöä. Varmentajasäilö auttaa varmistamaan, että varmentajat noudattavat käyttäjien tietoturvaan liittyviä hyviä käytäntöjä.
+
+cert-error-mitm-connection = { -brand-short-name } käyttää Mozillan varmentajasäilöä varmentamaan yhteyden turvallisuuden, käyttöjärjestelmään asennettujen varmenteiden sijasta. Siispä jos virustorjuntaohjelma tai verkko kaappaa yhteyden käyttäen varmennetta, jonka varmentaja ei ole Mozillan varmentajasäilössä, yhteyttä pidetään epäturvallisena.
+
+cert-error-trust-unknown-issuer-intro = Joku saattaa yrittää tekeytyä täksi sivustoksi eikä sivustolle siirtymistä siksi tulisi jatkaa.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-trust-unknown-issuer = Sivustot todistavat identiteettinsä varmenteella. { -brand-short-name } ei luota palvelimeen { $hostname }, koska sen varmenteen myöntäjä on tuntematon, varmenne on allekirjoitettu itsellään tai palvelin ei lähetä oikeita välivarmenteita.
+
+cert-error-trust-cert-invalid = Varmenteeseen ei luoteta, koska sen varmentajan varmenne ei ole kelvollinen.
+
+cert-error-trust-untrusted-issuer = Varmenteeseen ei luoteta, koska sen myöntäjän varmenteeseen ei luoteta.
+
+cert-error-trust-signature-algorithm-disabled = Varmenteeseen ei luoteta, koska se on allekirjoitettu allekirjoitusalgoritmilla, joka ei ole turvallinen.
+
+cert-error-trust-expired-issuer = Varmenteeseen ei luoteta, koska sen myöntäjän varmenne on vanhentunut.
+
+cert-error-trust-self-signed = Varmenteeseen ei luoteta, koska se on allekirjoitettu itsellään.
+
+cert-error-trust-symantec = Varmenteisiin, joiden myöntäjänä on GeoTrust, RapidSSL, Symantec, Thawte tai VeriSign, ei enää luoteta, koska nämä varmenteiden myöntäjät eivät noudattaneet tietoturvakäytäntöjä.
+
+cert-error-untrusted-default = Varmenteen lähde ei ole luotettu.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-domain-mismatch = Sivustot todistavat identiteettinsä varmenteella. { -brand-short-name } ei luota tähän sivustoon, koska sen käyttämä varmenne ei ole kelvollinen palvelimelle { $hostname }.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $alt-name (String) - Alternate domain name for which the cert is valid.
+cert-error-domain-mismatch-single = Sivustot todistavat identiteettinsä varmenteella. { -brand-short-name } ei luota tähän sivustoon, koska sen käyttämä varmenne ei ole kelvollinen palvelimelle { $hostname }. Varmenne on kelvollinen vain kohteelle <a data-l10n-name="domain-mismatch-link">{ $alt-name }</a>.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $alt-name (String) - Alternate domain name for which the cert is valid.
+cert-error-domain-mismatch-single-nolink = Sivustot todistavat identiteettinsä varmenteella. { -brand-short-name } ei luota tähän sivustoon, koska sen käyttämä varmenne ei ole kelvollinen palvelimelle { $hostname }. Varmenne on kelvollinen vain kohteelle { $alt-name }.
+
+# Variables:
+# $subject-alt-names (String) - Alternate domain names for which the cert is valid.
+cert-error-domain-mismatch-multiple = Sivustot todistavat identiteettinsä varmenteella. { -brand-short-name } ei luota tähän sivustoon, koska sen käyttämä varmenne ei ole kelvollinen palvelimelle { $hostname }. Varmenne on kelvollinen vain palvelimille: { $subject-alt-names }
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $not-after-local-time (Date) - Certificate is not valid after this time.
+cert-error-expired-now = Sivustot todistavat identiteettinsä varmenteella, joka on voimassa määräajan. Varmenne sivustolle { $hostname } vanheni { $not-after-local-time }.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $not-before-local-time (Date) - Certificate is not valid before this time.
+cert-error-not-yet-valid-now = Sivustot todistavat identiteettinsä varmenteella, joka on voimassa määräajan. Varmenne sivustolle { $hostname } on voimassa vasta { $not-before-local-time }.
+
+# Variables:
+# $error (String) - NSS error code string that specifies type of cert error. e.g. unknown issuer, invalid cert, etc.
+cert-error-code-prefix-link = Virhekoodi: <a data-l10n-name="error-code-link">{ $error }</a>
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-symantec-distrust-description = Sivustot todistavat identiteettinsä varmenteella, jonka myöntää varmentaja. Useimmat selaimet eivät enää luota varmenteisiin, joiden varmentaja on GeoTrust, RapidSSL, Symantec, Thawte tai VeriSign. { $hostname } käyttää varmennetta, jonka on myöntänyt jokin ennalta mainituista varmentajista. Sivuston identiteettiä ei siksi voida todistaa.
+
+cert-error-symantec-distrust-admin = Voit ilmoittaa tästä ongelmasta sivuston ylläpitäjälle.
+
+# Variables:
+# $hasHSTS (Boolean) - Indicates whether HSTS header is present.
+cert-error-details-hsts-label = HTTP Strict Transport Security: { $hasHSTS }
+
+# Variables:
+# $hasHPKP (Boolean) - Indicates whether HPKP header is present.
+cert-error-details-key-pinning-label = HTTP Public Key Pinning: { $hasHPKP }
+
+cert-error-details-cert-chain-label = Certificate chain:
+
+open-in-new-window-for-csp-or-xfo-error = Avaa sivusto uuteen ikkunaan
+
+# Variables:
+# $hostname (String) - Hostname of the website blocked by csp or xfo error.
+csp-xfo-blocked-long-desc = Turvallisuutesi suojaamiseksi { $hostname } ei salli, että { -brand-short-name } näyttää sivun, jos se on upotettu toiselle sivulle. Jotta voit nähdä tämän sivun, sinun tulee avata se uudessa ikkunassa.
+
+## Messages used for certificate error titles
+
+connectionFailure-title = Yhdistäminen epäonnistui
+deniedPortAccess-title = Osoitteen käyttö on rajoitettu
+# "Hmm" is a sound made when considering or puzzling over something.
+# You don't have to include it in your translation if your language does not have a written word like this.
+dnsNotFound-title = Hmm. Sivua ei löydy.
+fileNotFound-title = Tiedostoa ei löytynyt
+fileAccessDenied-title = Tiedoston käyttö estettiin
+generic-title = Verkkopyyntöä ei kyetä toteuttamaan
+captivePortal-title = Kirjaudu verkkoon
+# "Hmm" is a sound made when considering or puzzling over something.
+# You don't have to include it in your translation if your language does not have a written word like this.
+malformedURI-title = Hmm. Tuo osoite ei näytä oikealta.
+netInterrupt-title = Tiedonsiirto keskeytyi
+notCached-title = Dokumentti on vanhentunut
+netOffline-title = Yhteydettömässä tilassa
+contentEncodingError-title = Sisällön koodausvirhe
+unsafeContentType-title = Vaarallinen tiedostotyyppi
+netReset-title = Yhteys keskeytyi
+netTimeout-title = Yhteyden aikakatkaisu
+unknownProtocolFound-title = Osoitetta ei ymmärretty
+proxyConnectFailure-title = Välityspalvelin kieltäytyy yhteydestä
+proxyResolveFailure-title = Välityspalvelinta ei löytynyt
+redirectLoop-title = Sivusto ei uudelleenohjaudu asianmukaisesti
+unknownSocketType-title = Odottamaton vastaus palvelimelta
+nssFailure2-title = Suojatun yhteyden muodostaminen epäonnistui
+csp-xfo-error-title = { -brand-short-name } ei voi avata tätä sivua
+corruptedContentError-title = Sisältö vioittunut -virhe
+remoteXUL-title = XUL-koodia etänä
+sslv3Used-title = Ei voitu muodostaa suojattua yhteyttä
+inadequateSecurityError-title = Yhteys ei ole suojattu
+blockedByPolicy-title = Estetty sivu
+clockSkewError-title = Tietokoneen kello on väärässä ajassa
+networkProtocolError-title = Verkkoyhteyskäytännön virhe
+nssBadCert-title = Varoitus: mahdollinen tietoturvariski
+nssBadCert-sts-title = Ei yhdistetty: mahdollinen turvallisuusongelma
+certerror-mitm-title = Ohjelmisto estää { -brand-short-name }ia yhdistämästä turvallisesti tähän sivustoon

--- a/overrides/fi/brand.ftl
+++ b/overrides/fi/brand.ftl
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+## Firefox Brand
+##
+## Firefox must be treated as a brand, and kept in English.
+## It cannot be:
+## - Declined to adapt to grammatical case.
+## - Transliterated.
+## - Translated.
+##
+## Reference: https://www.mozilla.org/styleguide/communications/translation/
+
+-brand-short-name = Browser
+-brand-full-name = Sailfish Browser
+# This brand name can be used in messages where the product name needs to
+# remain unchanged across different versions (Nightly, Beta, etc.).
+-brand-product-name = Browser
+-vendor-short-name = Sailfish

--- a/overrides/netError.css
+++ b/overrides/netError.css
@@ -141,19 +141,21 @@ button.inProgress {
  * This shows an arrow to the right of the h2 element, and hides the content when collapsed="true". */
 .expander {
   margin: var(--moz-vertical-spacing) 0;
-  background-image: url("chrome://geckoview/skin/images/dropmarker.svg");
-  background-repeat: no-repeat;
-  /* dropmarker.svg is 10x7. Ensure that its centered in the middle of an 18x18 box */
-  background-position: 3px 5.5px;
-  background-size: 10px 7px;
-  padding-left: 18px;
+  display: flex;
+  align-items: center
 }
 
-div[collapsed="true"] > .expander {
-  background-image: url("chrome://geckoview/skin/images/dropmarker-right.svg");
-  /* dropmarker.svg is 7x10. Ensure that its centered in the middle of an 18x18 box */
-  background-size: 7px 10px;
-  background-position: 5.5px 4px;
+.expander-caret {
+  background-image: url("chrome://embedlite/skin/images/dropmarker.svg");
+  background-repeat: no-repeat;
+  background-position: center;
+  display: inline flex;
+  width: 18px;
+  height: 18px;
+}
+
+div[collapsed="true"] .expander-caret {
+  transform: rotate(270deg)
 }
 
 div[hidden] > .expander,

--- a/overrides/ru/aboutCertError.ftl
+++ b/overrides/ru/aboutCertError.ftl
@@ -1,0 +1,126 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-intro = { $hostname } использует недействительный сертификат безопасности.
+
+cert-error-mitm-intro = Веб-сайты подтверждают свою подлинность с помощью сертификатов, выдаваемых центрами сертификации.
+
+cert-error-mitm-mozilla = { -brand-short-name } поддерживается некоммерческой организацией Mozilla, которая имеет собственное полностью открытое хранилище сертификатов центров сертификации. Это хранилище помогает убедиться, что центры сертификации следуют лучшим практикам обеспечения безопасности пользователей.
+
+cert-error-mitm-connection = Для проверки защиты соединения { -brand-short-name } использует хранилище сертификатов центров сертификации Mozilla, а не хранилище, встроенное в операционную систему пользователя. Так что, если антивирусная или сетевая программа перехватывает соединение, используя сертификат безопасности, выданный центром сертификации, отсутствующем в хранилище Mozilla, соединение считается небезопасным.
+
+cert-error-trust-unknown-issuer-intro = Кто-то может пытаться подменить настоящий сайт и вам лучше не продолжать.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-trust-unknown-issuer = Веб-сайты подтверждают свою подлинность с помощью сертификатов. { -brand-short-name } не доверяет { $hostname }, потому что издатель его сертификата неизвестен, сертификат является самоподписанным, или сервер не отправляет корректные промежуточные сертификаты.
+
+cert-error-trust-cert-invalid = К сертификату нет доверия, так как он был издан с использованием недействительного сертификата центра сертификации (CA).
+
+cert-error-trust-untrusted-issuer = К сертификату нет доверия, так как к сертификату его издателя нет доверия.
+
+cert-error-trust-signature-algorithm-disabled = К сертификату нет доверия, так как он был подписан с использованием алгоритма подписи, который был отключён, так как алгоритм небезопасен.
+
+cert-error-trust-expired-issuer = К сертификату нет доверия, так как у сертификата его издателя истёк срок действия.
+
+cert-error-trust-self-signed = К сертификату нет доверия, так как он является самоподписанным.
+
+cert-error-trust-symantec = Сертификаты, выпущенные GeoTrust, RapidSSL, Symantec, Thawte и VeriSign, более не считаются безопасными, так как эти центры сертификации в прошлом не соблюдали правила обеспечения безопасности.
+
+cert-error-untrusted-default = К источнику, издавшему сертификат, нет доверия.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-domain-mismatch = Веб-сайты подтверждают свою подлинность с помощью сертификатов. { -brand-short-name } не доверяет этому сайту, потому что он использует сертификат, недействительный для { $hostname }.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $alt-name (String) - Alternate domain name for which the cert is valid.
+cert-error-domain-mismatch-single = Веб-сайты подтверждают свою подлинность с помощью сертификатов. { -brand-short-name } не доверяет этому сайту, потому что он использует сертификат, недействительный для { $hostname }. Сертификат действителен только для <a data-l10n-name="domain-mismatch-link">{ $alt-name }</a>.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $alt-name (String) - Alternate domain name for which the cert is valid.
+cert-error-domain-mismatch-single-nolink = Веб-сайты подтверждают свою подлинность с помощью сертификатов. { -brand-short-name } не доверяет этому сайту, потому что он использует сертификат, недействительный для { $hostname }. Сертификат действителен только для { $alt-name }.
+
+# Variables:
+# $subject-alt-names (String) - Alternate domain names for which the cert is valid.
+cert-error-domain-mismatch-multiple = Веб-сайты подтверждают свою подлинность с помощью сертификатов. { -brand-short-name } не доверяет этому сайту, потому что он использует сертификат, недействительный для { $hostname }. Сертификат действителен только для следующих доменов: { $subject-alt-names }
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $not-after-local-time (Date) - Certificate is not valid after this time.
+cert-error-expired-now = Веб-сайты подтверждают свою подлинность с помощью сертификатов, имеющих ограниченный срок действия. Срок действия сертификата для { $hostname } истёк { $not-after-local-time }.
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+# $not-before-local-time (Date) - Certificate is not valid before this time.
+cert-error-not-yet-valid-now = Веб-сайты подтверждают свою подлинность с помощью сертификатов, имеющих ограниченный срок действия. Сертификат для { $hostname } начнёт действовать не ранее { $not-before-local-time }.
+
+# Variables:
+# $error (String) - NSS error code string that specifies type of cert error. e.g. unknown issuer, invalid cert, etc.
+cert-error-code-prefix-link = Код ошибки: <a data-l10n-name="error-code-link">{ $error }</a>
+
+# Variables:
+# $hostname (String) - Hostname of the website with cert error.
+cert-error-symantec-distrust-description = Веб-сайты подтверждают свою подлинность с помощью сертификатов, выдаваемых центрами сертификации. Большинство браузеров больше не доверяют сертификатам, выпущенным GeoTrust, RapidSSL, Symantec, Thawte и VeriSign. { $hostname } использует сертификат от одного из этих центров, поэтому его подлинность не может быть подтверждена.
+
+cert-error-symantec-distrust-admin = Вы можете уведомить об этой проблеме администратора веб-сайта.
+
+# Variables:
+# $hasHSTS (Boolean) - Indicates whether HSTS header is present.
+cert-error-details-hsts-label = Форсированное защищённое соединение HTTP (HSTS): { $hasHSTS }
+
+# Variables:
+# $hasHPKP (Boolean) - Indicates whether HPKP header is present.
+cert-error-details-key-pinning-label = Привязка открытого ключа HTTP (HPKP): { $hasHPKP }
+
+cert-error-details-cert-chain-label = Цепочка сертификата:
+
+open-in-new-window-for-csp-or-xfo-error = Открыть сайт в новом окне
+
+# Variables:
+# $hostname (String) - Hostname of the website blocked by csp or xfo error.
+csp-xfo-blocked-long-desc = Для обеспечения вашей безопасности { $hostname } не разрешил { -brand-short-name } отобразить страницу, так как она встроена в другой сайт. Чтобы увидеть эту страницу, вам нужно открыть её в новом окне.
+
+## Messages used for certificate error titles
+
+connectionFailure-title = Попытка соединения не удалась
+deniedPortAccess-title = Обращение к данному адресу заблокировано
+# "Hmm" is a sound made when considering or puzzling over something.
+# You don't have to include it in your translation if your language does not have a written word like this.
+dnsNotFound-title = Хмм. Нам не удаётся найти этот сайт.
+fileNotFound-title = Файл не найден
+fileAccessDenied-title = В доступе к файлу отказано
+generic-title = Ой.
+captivePortal-title = Вход в сеть
+# "Hmm" is a sound made when considering or puzzling over something.
+# You don't have to include it in your translation if your language does not have a written word like this.
+malformedURI-title = Хмм. Этот адрес не выглядит правильным.
+netInterrupt-title = Соединение было прервано
+notCached-title = Документ просрочен
+netOffline-title = Автономный режим
+contentEncodingError-title = Ошибка в типе содержимого
+unsafeContentType-title = Небезопасный тип файла
+netReset-title = Соединение было сброшено
+netTimeout-title = Время ожидания соединения истекло
+unknownProtocolFound-title = Неизвестный тип адреса
+proxyConnectFailure-title = Прокси-сервер отказывается принимать соединения
+proxyResolveFailure-title = Не удалось найти прокси-сервер
+redirectLoop-title = Циклическое перенаправление на странице
+unknownSocketType-title = Неизвестный/неопознанный ответ сервера
+nssFailure2-title = Ошибка при установлении защищённого соединения
+csp-xfo-error-title = { -brand-short-name } не может открыть эту страницу
+corruptedContentError-title = Ошибка искажения содержимого
+remoteXUL-title = Удалённый XUL
+sslv3Used-title = Установка защищённого соединения не удалась
+inadequateSecurityError-title = Ваше соединение не защищено
+blockedByPolicy-title = Заблокированная страница
+clockSkewError-title = Часы вашего компьютера установлены неправильно
+networkProtocolError-title = Ошибка сетевого протокола
+nssBadCert-title = Предупреждение: Вероятная угроза безопасности
+nssBadCert-sts-title = Соединение не установлено: Вероятная угроза безопасности
+certerror-mitm-title = Программное обеспечение не даёт { -brand-short-name } безопасно подключиться к этому сайту

--- a/overrides/ru/brand.ftl
+++ b/overrides/ru/brand.ftl
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+## Firefox Brand
+##
+## Firefox must be treated as a brand, and kept in English.
+## It cannot be:
+## - Declined to adapt to grammatical case.
+## - Transliterated.
+## - Translated.
+##
+## Reference: https://www.mozilla.org/styleguide/communications/translation/
+
+-brand-short-name = Browser
+-brand-full-name = Sailfish Browser
+# This brand name can be used in messages where the product name needs to
+# remain unchanged across different versions (Nightly, Beta, etc.).
+-brand-product-name = Browser
+-vendor-short-name = Sailfish

--- a/tools/mine-localisation-files.py
+++ b/tools/mine-localisation-files.py
@@ -166,6 +166,9 @@ def mine_locale(locale, date):
         # overrides/en-US/brand.properties
         shutil.copyfile(git_root + '/overrides/en-US/brand.properties', folder + '/brand.properties')
 
+        # overrides/en-US/brand.ftl
+        shutil.copyfile(git_root + '/overrides/en-US/brand.ftl', folder + '/brand.ftl')
+
         # ./mobile/overrides/appstrings.properties
         convert_file('appstrings.properties', './mobile/overrides', folder)
 
@@ -174,6 +177,9 @@ def mine_locale(locale, date):
 
         # ./mobile/android/chrome/aboutCertError.dtd
         convert_file('aboutCertError.dtd', './mobile/android/chrome', folder)
+
+        # ./browser/browser/aboutCertError.ftl
+        convert_file('aboutCertError.ftl', './browser/browser', folder)
 
     # Clean up
     if cloned:


### PR DESCRIPTION
The description of the error is no longer encoded in the about:certerror
URL and needs to be constructed in the page itself.

Also fix the caret icon so it's apparent when the collapsed headings have
been expanded as with neither that nor content it wasn't apparent when
clicking worked.