### PR TITLE
[embedlite-components] Fixed password save dialog showing incorrect host. Fixes JB#57143

### DIFF
--- a/jscomps/LoginManagerPrompter.js
+++ b/jscomps/LoginManagerPrompter.js
@@ -1049,7 +1049,7 @@ LoginManagerPrompter.prototype = {
 
     // We reuse the existing message, even if it expects a username, until we
     // switch to the final terminology in bug 1144856.
-    var displayHost = this._getShortDisplayHost(aNewLogin.hostname);
+    var displayHost = aNewLogin.displayOrigin;
     var notificationTextBundle = ["passwordChangeTitle"];
     var usernames = logins.map(l => this._sanitizeUsername(l.username));
     var dialogTextBundle  = ["userSelectText2"];
@@ -1138,7 +1138,7 @@ LoginManagerPrompter.prototype = {
   _showChangeLoginNotification(aBrowser, aOldLogin, aNewLogin) {
     // We reuse the existing message, even if it expects a username, until we
     // switch to the final terminology in bug 1144856.
-    var displayHost = this._getShortDisplayHost(aOldLogin.origin);
+    var displayHost = aOldLogin.displayOrigin;
     var notificationTextBundle;
     var formData = {
       "displayHost": displayHost
@@ -1419,32 +1419,7 @@ LoginManagerPrompter.prototype = {
     return uri.scheme + "://" + uri.displayHostPort;
   },
 
-  /**
-   * Converts a login's origin field to a short string for
-   * prompting purposes. Eg, "http://foo.com" --> "foo.com", or
-   * "ftp://www.site.co.uk" --> "site.co.uk".
-   */
-  _getShortDisplayHost(aURIString) {
-    var displayHost;
-
-    var idnService = Cc["@mozilla.org/network/idn-service;1"].getService(
-      Ci.nsIIDNService
-    );
-    try {
-      var uri = Services.io.newURI(aURIString);
-      var baseDomain = Services.eTLD.getBaseDomain(uri);
-      displayHost = idnService.convertToDisplayIDN(baseDomain, {});
-    } catch (e) {
-      log.warn("_getShortDisplayHost couldn't process", aURIString);
-    }
-
-    if (!displayHost) {
-      displayHost = aURIString;
-    }
-
-    return displayHost;
-  },
-
+    
   /* ---------- Internal Methods (new) ---------- */
 
   /**

--- a/jscomps/LoginManagerPrompter.js
+++ b/jscomps/LoginManagerPrompter.js
@@ -1418,7 +1418,6 @@ LoginManagerPrompter.prototype = {
 
     return uri.scheme + "://" + uri.displayHostPort;
   },
-
     
   /* ---------- Internal Methods (new) ---------- */
 

--- a/jscomps/LoginManagerPrompter.js
+++ b/jscomps/LoginManagerPrompter.js
@@ -1491,7 +1491,7 @@ LoginManagerPrompter.prototype = {
    *        The login captured from the form.
    */
   _showSaveLoginNotification : function (aBrowser, aLogin) {
-    var displayHost = this._getShortDisplayHost(aLogin.hostname);
+    var displayHost = aLogin.displayOrigin;
     var notificationTextBundle = ["rememberPasswordMsgNoUsername", displayHost];
     var formData = {
       "displayHost": displayHost


### PR DESCRIPTION
When user saves password for site part1.hostname.com, the password save dialog asks "Save password for 'hostname.com'?", showing only Top Level Domain instead of full domain. So user might think he saves password for all subdomains of hostname.com (like part2.hostname.com, subpart4.part3.hostname.com etc.). In order to inform user more accurately, we should show full domain in that dialog.