### PR TITLE
[embedlite-components] Make selection handling more robust. Fixes JB#58662

### DIFF
--- a/jsscripts/SelectionHandler.js
+++ b/jsscripts/SelectionHandler.js
@@ -302,6 +302,10 @@ function SelectionHandler() {
    * content values.
    */
   this._onSelectionCopy = function _onSelectionCopy(aMsg) {
+    if (!this._cache || !this._cache.selection) {
+      return;
+    }
+
     let tap = {
       xPos: aMsg.xPos,
       yPos: aMsg.yPos,
@@ -365,7 +369,7 @@ function SelectionHandler() {
   this._onFail = function _onFail(aDbgMessage) {
     if (aDbgMessage && aDbgMessage.length > 0)
       Logger.debug(aDbgMessage);
-    this.sendAsync("Content:SelectionFail");
+    this.sendAsync("Content:SelectionFail", {});
     this._clearSelection();
     this.closeSelection();
   }


### PR DESCRIPTION
When trying to copy to clipboard without selection following got triggered:
> JavaScript error: chrome://embedlite/content/SelectionHandler.js,
> line 310: TypeError: this._cache.selection is undefined

Fix: return early if no cache or selection.

On error case following got triggered:
> JavaScript error: chrome://embedlite/content/SelectionHandler.js,
> line 66: TypeError: aJson is undefined

Fix: have json argument in all this.sendAsync calls.

Signed-off-by: Raine Makelainen <raine.makelainen@jolla.com>