### PR TITLE
[embedlite-components] Add initial linkTitle for context menu of an image. JB#61064

### DIFF
--- a/jsscripts/ContextMenuHandler.js
+++ b/jsscripts/ContextMenuHandler.js
@@ -94,6 +94,7 @@ var ContextMenuHandler = {
       if (popupNode instanceof Ci.nsIImageLoadingContent && popupNode.currentURI) {
         state.types.push("image");
         state.label = state.mediaURL = popupNode.currentURI.spec;
+        state.linkTitle = popupNode.textContent || popupNode.title;
         imageUrl = state.mediaURL;
         this._target = popupNode;
 


### PR DESCRIPTION
Previously linkTitle didn't necessary contain anything for an image when img element wasn't wrapped inside an anchor.

Can be tested like this:
```
scp jsscripts/ContextMenuHandler.js root@192.168.2.15:/usr/lib64/mozembedlite/chrome/embedlite/content/ContextMenuHandler.js
```

On device:
```
rm -rf .local/share/org.sailfishos/browser/.mozilla/startupCache/
```

Start browser