### PR TITLE
Change URL from git.sailfishos.org to github.com

### DIFF
--- a/rpm/embedlite-components-qt5.spec
+++ b/rpm/embedlite-components-qt5.spec
@@ -21,7 +21,7 @@ Summary:    EmbedLite components Qt5
 Version:    1.23.0
 Release:    1
 License:    MPLv2.0
-URL:        https://git.sailfishos.org/mer-core/embedlite-components
+URL:        https://github.com/sailfishos/embedlite-components
 Source0:    %{name}-%{version}.tar.bz2
 
 BuildRequires:  libtool


### PR DESCRIPTION
We redirect all git.sailfishos.org to github.com but it is better to have the correct url here to avoid confusion, when retrieving the URL with rpm, for instance.