### PR TITLE
Tell the observer if the download is coming from a private tab

### DIFF
--- a/jscomps/EmbedliteDownloadManager.js
+++ b/jscomps/EmbedliteDownloadManager.js
@@ -15,6 +15,7 @@ const Cu = Components.utils;
 const Cr = Components.results;
 
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+const { PrivateBrowsingUtils } = ChromeUtils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
 
 XPCOMUtils.defineLazyModuleGetter(this, "Downloads",
                                   "resource://gre/modules/Downloads.jsm");
@@ -78,6 +79,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-done",
                                        id: download.id,
+                                       privateMode: PrivateBrowsingUtils.isContentWindowPrivate(Services.ww.activeWindow) || false,
                                        saveAsPdf: download.saveAsPdf || false,
                                        targetPath: download.target.path
                                    }));
@@ -89,6 +91,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-fail",
                                        id: download.id,
+                                       privateMode: PrivateBrowsingUtils.isContentWindowPrivate(Services.ww.activeWindow) || false,
                                        saveAsPdf: download.saveAsPdf || false
                                    }));
     }
@@ -98,6 +101,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-cancel",
                                        id: download.id,
+                                       privateMode: PrivateBrowsingUtils.isContentWindowPrivate(Services.ww.activeWindow) || false,
                                        saveAsPdf: download.saveAsPdf || false
                                    }));
     }

--- a/jscomps/EmbedliteDownloadManager.js
+++ b/jscomps/EmbedliteDownloadManager.js
@@ -15,7 +15,6 @@ const Cu = Components.utils;
 const Cr = Components.results;
 
 const { XPCOMUtils } = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
-const { PrivateBrowsingUtils } = ChromeUtils.import("resource://gre/modules/PrivateBrowsingUtils.jsm");
 
 XPCOMUtils.defineLazyModuleGetter(this, "Downloads",
                                   "resource://gre/modules/Downloads.jsm");
@@ -56,6 +55,7 @@ let DownloadView = {
                                  JSON.stringify({
                                      msg: "dl-start",
                                      id: this.counter,
+                                     privateMode: download.source.isPrivate || false,
                                      saveAsPdf: download.saveAsPdf || false,
                                      displayName: download.target.path.split('/').slice(-1)[0],
                                      sourceUrl: download.source.url,
@@ -69,6 +69,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-progress",
                                        id: download.id,
+                                       privateMode: download.source.isPrivate || false,
                                        saveAsPdf: download.saveAsPdf || false,
                                        percent: download.progress
                                    }));
@@ -79,7 +80,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-done",
                                        id: download.id,
-                                       privateMode: PrivateBrowsingUtils.isContentWindowPrivate(Services.ww.activeWindow) || false,
+                                       privateMode: download.source.isPrivate || false,
                                        saveAsPdf: download.saveAsPdf || false,
                                        targetPath: download.target.path
                                    }));
@@ -91,7 +92,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-fail",
                                        id: download.id,
-                                       privateMode: PrivateBrowsingUtils.isContentWindowPrivate(Services.ww.activeWindow) || false,
+                                       privateMode: download.source.isPrivate || false,
                                        saveAsPdf: download.saveAsPdf || false
                                    }));
     }
@@ -101,7 +102,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-cancel",
                                        id: download.id,
-                                       privateMode: PrivateBrowsingUtils.isContentWindowPrivate(Services.ww.activeWindow) || false,
+                                       privateMode: download.source.isPrivate || false,
                                        saveAsPdf: download.saveAsPdf || false
                                    }));
     }
@@ -113,6 +114,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-progress",
                                        id: download.id,
+                                       privateMode: download.source.isPrivate || false,
                                        saveAsPdf: download.saveAsPdf || false,
                                        percent: download.progress
                                    }));
@@ -124,6 +126,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-done",
                                        id: download.id,
+                                       privateMode: download.source.isPrivate || false,
                                        saveAsPdf: download.saveAsPdf || false,
                                        targetPath: download.target.path
                                    }));
@@ -136,6 +139,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-fail",
                                        id: download.id,
+                                       privateMode: download.source.isPrivate || false,
                                        saveAsPdf: download.saveAsPdf || false
                                    }));
     }
@@ -146,6 +150,7 @@ let DownloadView = {
                                    JSON.stringify({
                                        msg: "dl-cancel",
                                        id: download.id,
+                                       privateMode: download.source.isPrivate || false,
                                        saveAsPdf: download.saveAsPdf || false
                                    }));
     }
@@ -156,6 +161,7 @@ let DownloadView = {
                                    JSON.stringify({
                                      msg: "dl-start",
                                      id: download.id,
+                                     privateMode: download.source.isPrivate || false,
                                      saveAsPdf: download.saveAsPdf || false,
                                      displayName: download.target.path.split('/').slice(-1)[0],
                                      sourceUrl: download.source.url,


### PR DESCRIPTION
Follow up of [sailfish-browser!1057](https://github.com/sailfishos/sailfish-browser/pull/1057) to propagate the private mode information.