### PR TITLE
Unnecessary finder

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
-AC_INIT(configure.ac)
-AM_CONFIG_HEADER(config.h)
+AC_INIT([foocomponent], [1.0.0])
+AC_CONFIG_SRCDIR([configure.ac])
+AC_CONFIG_HEADERS(config.h)
 
-VERSION=1.0.0
+AM_INIT_AUTOMAKE
 
-AM_INIT_AUTOMAKE(foocomponent, $VERSION)
-
-AC_OUTPUT([
+AC_CONFIG_FILES([
     Makefile
     jscomps/Makefile
     jsscripts/Makefile
     overrides/Makefile
 ])
+AC_OUTPUT

--- a/jsscripts/embedhelper.js
+++ b/jsscripts/embedhelper.js
@@ -204,12 +204,14 @@ EmbedHelper.prototype = {
         let searchAgain = aMessage.json.again;
         let searchBackwards = aMessage.json.backwards;
 
-        if (!searchText && this._finder) {
-          this._finder.removeSelection()
-          this._finder.destroy()
-          Services.focus.clearFocus(content);
+        if (!searchText) {
+          if (this._finder) {
+            this._finder.removeSelection()
+            this._finder.destroy()
+            Services.focus.clearFocus(content);
 
-          this._finder = null;
+            this._finder = null;
+          }
           return;
         }
 

--- a/rpm/embedlite-components-qt5.spec
+++ b/rpm/embedlite-components-qt5.spec
@@ -10,7 +10,6 @@ BuildRequires:  libtool
 BuildRequires:  automake
 BuildRequires:  autoconf
 Requires:  xulrunner-qt5
-Conflicts: embedlite-components
 
 %description
 EmbedLite Components required for embedded browser UI


### PR DESCRIPTION
Beef:

    Sailfish-browser startup triggers now search reset. While that could
    be avoided, the code here is already considering empty search string
    as request to finish the search if such was initialized.

Cleaned up the build and removed reference to ancient qt4 packaging while at it.